### PR TITLE
Use complete namespace for sqlalchemy.engine

### DIFF
--- a/mara_db/dbs.py
+++ b/mara_db/dbs.py
@@ -4,12 +4,12 @@ from contextlib import contextmanager
 from functools import lru_cache
 
 from mara_db import config
-from sqlalchemy import engine
+import sqlalchemy.engine
 from sqlalchemy import orm
 
 
 @lru_cache(maxsize=None)
-def engine(alias) -> engine.Engine:
+def engine(alias) -> sqlalchemy.engine.Engine:
     """Returns a database engine by alias"""
     databases = config.databases()
     if alias not in databases:


### PR DESCRIPTION
Before there was a problem with two different engines available under mara_db.dbs. Now only "our" engine is there.

closes: #1