### PR TITLE
Add way for DBs to agree on a common copy_command format

### DIFF
--- a/mara_db/dbs.py
+++ b/mara_db/dbs.py
@@ -17,6 +17,44 @@ def db(alias):
 class DB:
     """Generic database connection definition"""
 
+    def copy_to_stdout_format(self) -> dict:
+        """Dict with the formatting options to which the copy_to_stdout_command adheres
+
+        The formatting options must be the valid value for the implementation
+        of copy_to_stdout_command for this type of DB.
+
+        The dict must contain the following keys and the values should be
+        list of possible values for that option.
+
+        csv_format: [False, True] -> whether the DB can output CSV
+        skip_header: [False, True] -> whether this DB can skip outputting headers
+        delimiter_char: [str] -> possible delimiter chars. List all of [',', ';','|'] which apply
+        quote_char: [str] -> possible quote chars. List all of ['\'', '"'] which apply
+        null_value_string: [str] -> possible NULL value representations. List all of ['NULL', ''] which apply
+
+        """
+        raise NotImplementedError()
+
+    def possible_copy_from_stdin_formats(self) -> dict:
+        """Dict with possible (CSV) formatting options to be passed to copy_from_stdin_command
+
+        The formatting options must be valid values for the implementation
+        of copy_to_stdout_command for this type of DB.
+
+        The dict must contain the following keys and the values should be
+        list of possible values for that option. The default value should be first, so that
+        is chosen on the input side
+
+        csv_format: [False, True] -> whether the DB can output CSV
+        skip_header: [False, True] -> whether this DB can skip outputting headers
+        delimiter_char: [str] -> possible delimiter chars. List all of [',', ';','|','\t'] which apply
+        quote_char: [str] -> possible quote chars. List all of ['\'', '"'] which apply
+        null_value_string: [str] -> possible NULL value representations. List all of ['NULL', '', '\\N'] which apply
+        timezone: [True, False]-> whether or not a Timezone can be set
+
+        """
+        raise NotImplementedError()
+
     def __repr__(self) -> str:
         return (f'<{self.__class__.__name__}: '
                 + ', '.join([f'{var}={"*****" if var =="password" else getattr(self,var)}'
@@ -33,6 +71,26 @@ class PostgreSQLDB(DB):
         self.user = user
         self.password = password
 
+    def copy_to_stdout_format(self) -> dict:
+        """Dict with formatting options for the output of the copy_to_stdout_command"""
+        return {
+            'csv_format': [True],
+            'skip_header': [False],
+            'delimiter_char' : ['\t'],
+            'quote_char' : ['"'],
+            'null_value_string': ['\\N']
+        }
+
+    def possible_copy_from_stdin_formats(self) -> dict:
+        """Dict with possible formatting options to be passed to copy_from_stdin_command"""
+        return {
+            'csv_format': [True, False],
+            'skip_header': [True, False],
+            'delimiter_char': [',', ';', '|','\t'],
+            'quote_char': ['\'', '"'],
+            'null_value_string': ['NULL', '', '\\N']
+        }
+
 
 class MysqlDB(DB):
     def __init__(self, host: str = None, port: int = None, database: str = None,
@@ -45,6 +103,16 @@ class MysqlDB(DB):
         self.ssl = ssl
         self.charset = charset
 
+    def copy_to_stdout_format(self) -> dict:
+        """Dict with formatting options for the output of the copy_to_stdout_command"""
+        return {
+            'csv_format': [False],
+            'skip_header': [False],
+            'delimiter_char': ['\t'],
+            'quote_char': ['"'],
+            'null_value_string': ['NULL']
+        }
+
 
 class SQLServerDB(DB):
     def __init__(self, host: str = None, database: str = None, user: str = None, password: str = None):
@@ -52,3 +120,13 @@ class SQLServerDB(DB):
         self.database = database
         self.user = user
         self.password = password
+
+    def copy_to_stdout_format(self) -> dict:
+        """Dict with formatting options for the output of the copy_to_stdout_command"""
+        return {
+            'csv_format': [True],
+            'skip_header': [True],
+            'delimiter_char': [','],
+            'quote_char': ['"'],
+            'null_value_string': ['']
+        }


### PR DESCRIPTION
Both the source and the target define possible formats (currently the source
only allows one single value per option) and there is a new functions which
computes a common format spec.

```python
import mara_db.dbs
import mara_db.shell
target = mara_db.dbs.PostgreSQLDB()
sources = [mara_db.dbs.MysqlDB(), mara_db.dbs.PostgreSQLDB(), mara_db.dbs.SQLServerDB()]
for source in sources:
    print(type(source), mara_db.shell.get_common_copy_format(source, target))
print(mara_db.shell.copy_command(mara_db.dbs.SQLServerDB(database='source_db'), mara_db.dbs.PostgreSQLDB(database='target_db'), 'target_table', None))
```

```
<class 'mara_db.dbs.MysqlDB'> {'csv_format': False, 'skip_header': False, 'delimiter_char': '\t', 'quote_char': '"', 'null_value_string': 'NULL'}
<class 'mara_db.dbs.PostgreSQLDB'> {'csv_format': True, 'skip_header': False, 'delimiter_char': '\t', 'quote_char': '"', 'null_value_string': '\\N'}
<class 'mara_db.dbs.SQLServerDB'> {'csv_format': True, 'skip_header': True, 'delimiter_char': ',', 'quote_char': '"', 'null_value_string': ''}
sed 's/\\\\$/\$/g;s/\$/\\\\$/g' \
  | sqsh  -D source_db -m csv \
  | PGTZ=Europe/Berlin PGOPTIONS=--client-min-messages=warning psql --echo-all --no-psqlrc --set ON_ERROR_STOP=on target_db \
      --command="COPY target_table FROM STDIN WITH CSV HEADER"
```

Open:
* [x] Change the copy_command to use it
* [ ] Make copy_to_stdout actually flexible by letting them take these options (and fail on wrong ones)?
* [ ] Check that the current specs make sense...
* [x] Instead of adding methods on `DB` add these as a singledispatch functions? IMO these are fine on DB...