### PR TITLE
Quote postgresql password in case of problematic characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
-## 3.2.0 - 3.2.2 (2019-04-04)
+## 3.2.0 - 3.2.3 (2019-04-11)
 
 - Add oracle db access
 - Add SSL standard parameters to PostgreSQL connection string
 - Add missing footer parameter to Oracle copy to stdout command
-- Change arguments for sqsh client to return non zero exitcode in error case      
+- Change arguments for sqsh client to return non zero exitcode in error case
+- Add single quotes around PostgreSQL passwords to prevent bash errors when the password contains certain characters
 
 ## 3.1.0 - 3.1.2 (2018-08-30)
 

--- a/mara_db/shell.py
+++ b/mara_db/shell.py
@@ -46,7 +46,7 @@ def __(alias: str, timezone: str = None, echo_queries: bool = True):
 @query_command.register(dbs.PostgreSQLDB)
 def __(db: dbs.PostgreSQLDB, timezone: str = None, echo_queries: bool = True):
     return (f'PGTZ={timezone or config.default_timezone()} '
-            + (f'PGPASSWORD={db.password} ' if db.password else '')
+            + (f"PGPASSWORD='{db.password}' " if db.password else '')
             + (f'PGSSLMODE={db.sslmode} ' if db.sslmode else '')
             + (f'PGSSLROOTCERT={db.sslrootcert} ' if db.sslrootcert else '')
             + (f'PGSSLCERT={db.sslcert} ' if db.sslcert else '')
@@ -63,7 +63,7 @@ def __(db: dbs.PostgreSQLDB, timezone: str = None, echo_queries: bool = True):
 @query_command.register(dbs.RedshiftDB)
 def __(db: dbs.RedshiftDB, timezone: str = None, echo_queries: bool = True):
     return (f'PGTZ={timezone or config.default_timezone()} '
-            + (f'PGPASSWORD={db.password} ' if db.password else '')
+            + (f"PGPASSWORD='{db.password}' " if db.password else '')
             + ' psql'
             + (f' --username={db.user}' if db.user else '')
             + (f' --host={db.host}' if db.host else '')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mara-db',
-    version='3.2.2',
+    version='3.2.3',
 
     description='Configuration and monitoring of database connections',
 


### PR DESCRIPTION
If the pg password contains special characters like parentheses, they need to quoted so bash doesn't throw an error.

Formerly part of #15