### PR TITLE
Fixed 1 issue of type: PYTHON_E241 throughout 1 file in repo.

### DIFF
--- a/mara_db/shell.py
+++ b/mara_db/shell.py
@@ -290,7 +290,7 @@ def __(source_db: dbs.PostgreSQLDB, target_db: dbs.PostgreSQLDB, target_table: s
     return (copy_to_stdout_command(source_db) + ' \\\n'
             + "  | sed 's#\\\\#\\\\\\\\#g'"
             + '  | ' + copy_from_stdin_command(target_db, target_table=target_table,
-                                               null_value_string='', timezone=timezone,  delimiter_char=chr(31)))
+                                               null_value_string='', timezone=timezone, delimiter_char=chr(31)))
 
 
 @copy_command.register(dbs.MysqlDB, dbs.PostgreSQLDB)


### PR DESCRIPTION
PYTHON_E241: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.