### PR TITLE
Fixed 1 issue of type: PYTHON_W291 throughout 1 file in repo.

### DIFF
--- a/mara_db/views.py
+++ b/mara_db/views.py
@@ -111,7 +111,7 @@ def draw_schema(db_alias: str, schemas: str):
         cursor.execute("""
 SELECT
   rel_namespace.nspname, rel.relname ,
-  parent_namespace.nspname, parent.relname 
+  parent_namespace.nspname, parent.relname
 FROM pg_inherits
   JOIN pg_class parent ON parent.oid = pg_inherits.inhparent
   JOIN pg_class rel ON rel.oid = pg_inherits.inhrelid


### PR DESCRIPTION
PYTHON_W291: 'Remove trailing whitespace.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.