### PR TITLE
Change field delimiter and additional pipe commands in pg 2 pg copy_command

### DIFF
--- a/mara_db/auto_migration.py
+++ b/mara_db/auto_migration.py
@@ -41,9 +41,9 @@ def auto_migrate(engine: sqlalchemy.engine.Engine, models: [sqlalchemy.sql.schem
         # create database if it does not exist
         if not sqlalchemy_utils.database_exists(engine.url):
             sqlalchemy_utils.create_database(engine.url)
-            print(f'Created database "{engine.url}"\n')
+            print(f'Created database "{engine.url!r}"\n')
     except Exception as e:
-        print(f'Could not access or create database "{engine.url}":\n{e}', file=sys.stderr)
+        print(f'Could not access or create database "{engine.url!r}":\n{e}', file=sys.stderr)
         return False
 
     # merge all models into a single metadata object


### PR DESCRIPTION
To copy json data from postgresql to postgresql, I need the ability to change the delimiter char used during the copy_command and need to inject an additional sed line to escape backslashes in json fields. This implements both as a (overwriteable) function. The default values are set to the original used values (tab char as delimiter and no additional sed line).

This is a configureable way for the reverted #15 

This also includes a commit which hides the password in migration messages (`repr(<sqlalachemy URL>)`) hides any password).

