### PR TITLE
Add new parameter csv_format to all copy command functions that allow…

### DIFF
--- a/mara_db/shell.py
+++ b/mara_db/shell.py
@@ -184,7 +184,8 @@ def __(db: dbs.PostgreSQLDB, header: bool = None, footer: bool = None,
 
     if csv_format:
         assert not (footer or header), 'unsupported when csv_format = True'
-        return f'''(echo "COPY (" && cat && echo ") TO STDOUT WITH {'CSV ' if csv_format else ''} DELIMITER '{delimiter_char}' ") \\\n''' \
+        return r" sed '/\;/q' | sed 's/\;.*//' " + '\\\n' \
+               + f'''| (echo "COPY (" && cat && echo ") TO STDOUT WITH {'CSV ' if csv_format else ''} DELIMITER '{delimiter_char}' ") \\\n''' \
                + '  | ' + query_command(db, echo_queries=False) + '\\\n' \
                + "  | sed '/^$/d'"  # remove empty lines
     else:
@@ -229,7 +230,7 @@ def __(db: dbs.SQLiteDB, header: bool = None, footer: bool = None, delimiter_cha
 
     if delimiter_char is None:
         delimiter_char = '\t'
-        
+
     assert all(v is None for v in [footer, csv_format]), "unimplemented parameter for SQLiteDB"
     header_argument = '-noheader' if not header else ''
     return query_command(db) + " " + header_argument + f" -separator '{delimiter_char}' -quote"

--- a/mara_db/shell.py
+++ b/mara_db/shell.py
@@ -1,6 +1,6 @@
 """
 Shell command generation for
-- running queries in databases via their comannd line clients
+- running queries in databases via their command line clients
 - copying data from, into and between databases
 """
 
@@ -14,7 +14,7 @@ from mara_db import dbs, config
 
 
 @singledispatch
-def query_command(db: object, timezone: str = None, echo_queries: bool = True) -> str:
+def query_command(db: object, timezone: str = None, echo_queries: bool = None) -> str:
     """
     Creates a shell command that receives a sql query from stdin and executes it
 
@@ -39,12 +39,15 @@ def query_command(db: object, timezone: str = None, echo_queries: bool = True) -
 
 
 @query_command.register(str)
-def __(alias: str, timezone: str = None, echo_queries: bool = True):
+def __(alias: str, timezone: str = None, echo_queries: bool = None):
     return query_command(dbs.db(alias), timezone=timezone, echo_queries=echo_queries)
 
 
 @query_command.register(dbs.PostgreSQLDB)
-def __(db: dbs.PostgreSQLDB, timezone: str = None, echo_queries: bool = True):
+def __(db: dbs.PostgreSQLDB, timezone: str = None, echo_queries: bool = None):
+    if echo_queries is None:
+        echo_queries = True
+
     return (f'PGTZ={timezone or config.default_timezone()} '
             + (f"PGPASSWORD='{db.password}' " if db.password else '')
             + (f'PGSSLMODE={db.sslmode} ' if db.sslmode else '')
@@ -61,7 +64,10 @@ def __(db: dbs.PostgreSQLDB, timezone: str = None, echo_queries: bool = True):
 
 
 @query_command.register(dbs.RedshiftDB)
-def __(db: dbs.RedshiftDB, timezone: str = None, echo_queries: bool = True):
+def __(db: dbs.RedshiftDB, timezone: str = None, echo_queries: bool = None):
+    if echo_queries is None:
+        echo_queries = True
+
     return (f'PGTZ={timezone or config.default_timezone()} '
             + (f"PGPASSWORD='{db.password}' " if db.password else '')
             + ' psql'
@@ -74,7 +80,8 @@ def __(db: dbs.RedshiftDB, timezone: str = None, echo_queries: bool = True):
 
 
 @query_command.register(dbs.MysqlDB)
-def __(db: dbs.MysqlDB, timezone: str = None, echo_queries: bool = True):
+def __(db: dbs.MysqlDB, timezone: str = None, echo_queries: bool = None):
+    assert all(v is None for v in [timezone, echo_queries]), "unimplemented parameter for MysqlDB"
     return ((f"MYSQL_PWD='{db.password}' " if db.password else '')
             + 'mysql '
             + (f' --user={db.user}' if db.user else '')
@@ -85,7 +92,9 @@ def __(db: dbs.MysqlDB, timezone: str = None, echo_queries: bool = True):
 
 
 @query_command.register(dbs.SQLServerDB)
-def __(db: dbs.SQLServerDB, timezone: str = None, echo_queries: bool = True):
+def __(db: dbs.SQLServerDB, timezone: str = None, echo_queries: bool = None):
+    assert all(v is None for v in [timezone, echo_queries]), "unimplemented parameter for SQLServerDB"
+
     # sqsh is not able to use '$' directly, it has to be quoted by two backslashes
     # first, undo the quoting in case it has already been applied, then quote
     command = "sed 's/\\\\\\\\$/\$/g;s/\$/\\\\\\\\$/g' | "
@@ -102,7 +111,9 @@ def __(db: dbs.SQLServerDB, timezone: str = None, echo_queries: bool = True):
 
 
 @query_command.register(dbs.OracleDB)
-def __(db: dbs.OracleDB, timezone: str = None, echo_queries: bool = True):
+def __(db: dbs.OracleDB, timezone: str = None, echo_queries: bool = None):
+    assert all(v is None for v in [timezone, echo_queries]), "unimplemented parameter for OracleDB"
+
     # sqlplus does not do anything when a statement is not terminated by a ';', add one to be sure
     return (  # Oracle needs a semicolon at the end, with no newlines before
         # Remove all trailing whitespace and then add a semicolon if not there yet
@@ -113,7 +124,9 @@ def __(db: dbs.OracleDB, timezone: str = None, echo_queries: bool = True):
 
 
 @query_command.register(dbs.SQLiteDB)
-def __(db: dbs.SQLiteDB, timezone: str = None, echo_queries: bool = True):
+def __(db: dbs.SQLiteDB, timezone: str = None, echo_queries: bool = None):
+    assert all(v is None for v in [timezone, echo_queries]), "unimplemented parameter for SQLiteDB"
+
     # sqlite does not complain if a file does not exist. Therefore check file existence first
     file_name = shlex.quote(str(db.file_name))
     return f'(test -f {file_name} && cat || >&2 echo {file_name} not found) \\\n' \
@@ -124,7 +137,11 @@ def __(db: dbs.SQLiteDB, timezone: str = None, echo_queries: bool = True):
 
 
 @singledispatch
-def copy_to_stdout_command(db: object, header: bool = False, footer: bool = False) -> str:
+def copy_to_stdout_command(db: object,
+                           header: bool = None,
+                           footer: bool = None,
+                           delimiter_char: str = None,
+                           csv_format: bool = None) -> str:
     """
     Creates a shell command that receives a query from stdin, executes it and writes the output to stdout
 
@@ -133,6 +150,8 @@ def copy_to_stdout_command(db: object, header: bool = False, footer: bool = Fals
         header: Whether a csv header with the column name(s) will be included or not.
             No header, by default. (not implemented in sqsh for SQLServerDB)
         footer: Whether a footer will be included or not. False by default. (Only implemented for PostgreSQLDB)
+        delimiter_char: str to delimit the fields in one row. Default: tab character
+        csv_format: Double quote 'difficult' strings (Only implemented for PostgreSQLDB)
 
     Returns:
         The composed shell command
@@ -146,40 +165,74 @@ def copy_to_stdout_command(db: object, header: bool = False, footer: bool = Fals
 
 
 @copy_to_stdout_command.register(str)
-def __(alias: str, header: bool = False, footer: bool = False):
-    return copy_to_stdout_command(dbs.db(alias), header=header, footer=footer)
+def __(alias: str, header: bool = None, footer: bool = None, delimiter_char: str = None, csv_format: bool = None):
+    return copy_to_stdout_command(dbs.db(alias), header=header, footer=footer,
+                                  delimiter_char=delimiter_char, csv_format=csv_format)
 
 
 @copy_to_stdout_command.register(dbs.PostgreSQLDB)
-def __(db: dbs.PostgreSQLDB, header: bool = False, footer: bool = False):
-    header_argument = '--tuples-only' if header == False else ''
-    footer_argument = '--pset="footer=off"' if footer == False else ''
-    return query_command(db, echo_queries=False) \
-           + " " + header_argument + " " + footer_argument + " --no-align --field-separator='\t' \\\n" \
-           + "  | sed '/^$/d'"  # remove empty lines
+def __(db: dbs.PostgreSQLDB, header: bool = None, footer: bool = None,
+       delimiter_char: str = None, csv_format: bool = None):
+    if header is None:
+        header = False
+
+    if footer is None:
+        footer = False
+
+    if delimiter_char is None:
+        delimiter_char = '\t'
+
+    if csv_format:
+        assert not (footer or header), 'unsupported when csv_format = True'
+        return f'''(echo "COPY (" && cat && echo ") TO STDOUT WITH {'CSV ' if csv_format else ''} DELIMITER '{delimiter_char}' ") \\\n''' \
+               + '  | ' + query_command(db, echo_queries=False) + '\\\n' \
+               + "  | sed '/^$/d'"  # remove empty lines
+    else:
+        header_argument = '--tuples-only' if not header else ''
+        footer_argument = '--pset="footer=off"' if not footer else ''
+        return (query_command(db, echo_queries=False)
+                + " " + header_argument + " " + footer_argument
+                + f" --no-align --field-separator='{delimiter_char}' \\\n"
+                + "  | sed '/^$/d'"  # remove empty lines
+                )
 
 
 @copy_to_stdout_command.register(dbs.MysqlDB)
-def __(db: dbs.MysqlDB, header: bool = False, footer: bool = False):
-    header_argument = '--skip-column-names' if header == False else ''
+def __(db: dbs.MysqlDB, header: bool = None, footer: bool = None, delimiter_char: str = None, csv_format: bool = None):
+    if header is None:
+        header = False
+
+    assert all(v is None for v in [footer, delimiter_char, csv_format]), "unimplemented parameter for MysqlDB"
+    header_argument = '--skip-column-names' if header is False else ''
     return query_command(db) + ' ' + header_argument
 
 
 @copy_to_stdout_command.register(dbs.SQLServerDB)
-def __(db: dbs.SQLServerDB, header: bool = False, footer: bool = False):
+def __(db: dbs.SQLServerDB, header: bool = None, footer: bool = None, delimiter_char: str = None,
+       csv_format: bool = None):
+    assert all(
+        v is None for v in [header, footer, delimiter_char, csv_format]), "unimplemented parameter for SQLServerDB"
     return query_command(db) + " -m csv"
 
 
 @copy_to_stdout_command.register(dbs.OracleDB)
-def __(db: dbs.OracleDB, header: bool = False, footer: bool = False):
+def __(db: dbs.OracleDB, header: bool = None, footer: bool = None, delimiter_char: str = None, csv_format: bool = None):
+    assert all(v is None for v in [header, footer, delimiter_char, csv_format]), "unimplemented parameter for OracleDB"
     return "(echo 'set markup csv on\nset feedback off\nset heading off' && cat)" \
            + " \\\n  | " + query_command(db)
 
 
 @copy_to_stdout_command.register(dbs.SQLiteDB)
-def __(db: dbs.SQLiteDB, header: bool = False, footer: bool = False):
-    header_argument = '-noheader' if header == False else ''
-    return query_command(db) + " " + header_argument + " -separator '\t' -quote"
+def __(db: dbs.SQLiteDB, header: bool = None, footer: bool = None, delimiter_char: str = None, csv_format: bool = None):
+    if header is None:
+        header = False
+
+    if delimiter_char is None:
+        delimiter_char = '\t'
+        
+    assert all(v is None for v in [footer, csv_format]), "unimplemented parameter for SQLiteDB"
+    header_argument = '-noheader' if not header else ''
+    return query_command(db) + " " + header_argument + f" -separator '{delimiter_char}' -quote"
 
 
 # -------------------------------
@@ -187,9 +240,9 @@ def __(db: dbs.SQLiteDB, header: bool = False, footer: bool = False):
 
 @singledispatch
 def copy_from_stdin_command(db: object, target_table: str,
-                            csv_format: bool = False, skip_header: bool = False,
+                            csv_format: bool = None, skip_header: bool = None,
                             delimiter_char: str = None, quote_char: str = None,
-                            null_value_string: str = None, timezone: str = None):
+                            null_value_string: str = None, timezone: str = None) -> str:
     """
     Creates a shell command that receives data from stdin and writes it to a table.
 
@@ -211,14 +264,15 @@ def copy_from_stdin_command(db: object, target_table: str,
 
     Examples:
         >>>> print(copy_from_stdin_command('mara', target_table='foo'))
-        PGTZ=Europe/Berlin PGOPTIONS=--client-min-messages=warning psql --username=root --host=localhost --echo-all --no-psqlrc --set ON_ERROR_STOP=on mara \
+        PGTZ=Europe/Berlin PGOPTIONS=--client-min-messages=warning psql --username=root --host=localhost \
+            --echo-all --no-psqlrc --set ON_ERROR_STOP=on mara \
             --command="COPY foo FROM STDIN WITH CSV"
     """
     raise NotImplementedError(f'Please implement copy_from_stdin_command for type "{db.__class__.__name__}"')
 
 
 @copy_from_stdin_command.register(str)
-def __(alias: str, target_table: str, csv_format: bool = False, skip_header: bool = False,
+def __(alias: str, target_table: str, csv_format: bool = None, skip_header: bool = None,
        delimiter_char: str = None, quote_char: str = None, null_value_string: str = None, timezone: str = None):
     return copy_from_stdin_command(
         dbs.db(alias), target_table=target_table, csv_format=csv_format, skip_header=skip_header,
@@ -227,18 +281,18 @@ def __(alias: str, target_table: str, csv_format: bool = False, skip_header: boo
 
 
 @copy_from_stdin_command.register(dbs.PostgreSQLDB)
-def __(db: dbs.PostgreSQLDB, target_table: str, csv_format: bool = False, skip_header: bool = False,
+def __(db: dbs.PostgreSQLDB, target_table: str, csv_format: bool = None, skip_header: bool = None,
        delimiter_char: str = None, quote_char: str = None, null_value_string: str = None, timezone: str = None):
     sql = f'COPY {target_table} FROM STDIN WITH'
     if csv_format:
         sql += ' CSV'
     if skip_header:
         sql += ' HEADER'
-    if delimiter_char != None:
+    if delimiter_char is not None:
         sql += f" DELIMITER AS '{delimiter_char}'"
-    if null_value_string != None:
+    if null_value_string is not None:
         sql += f" NULL AS '{null_value_string}'"
-    if quote_char != None:
+    if quote_char is not None:
         sql += f" QUOTE AS '{quote_char}'"
 
     return f'{query_command(db, timezone)} \\\n      --command="{sql}"'
@@ -248,7 +302,8 @@ def __(db: dbs.PostgreSQLDB, target_table: str, csv_format: bool = False, skip_h
 
 
 @multidispatch
-def copy_command(source_db: object, target_db: object, target_table: str, timezone: str):
+def copy_command(source_db: object, target_db: object, target_table: str,
+                 timezone = None, csv_format = None, delimiter_char = None) -> str:
     """
     Creates a shell command that
     - receives a sql query from stdin
@@ -256,65 +311,94 @@ def copy_command(source_db: object, target_db: object, target_table: str, timezo
     - writes the results of the query to `target_table` in `target_db`
 
     Args:
-        source: The database in which to run the query (either an alias or a `dbs.DB` object
+        source_db: The database in which to run the query (either an alias or a `dbs.DB` object
         target_db: The database where to write the query results (alias or db configuration)
         target_table: The table in which to write the query results
         timezone: Sets the timezone of the client, if applicable
+        csv_format: double quote 'difficult' strings
+        delimiter_char: The character that separates columns, default '\t'
+
 
     Returns:
         A shell command string
 
     Examples:
-        >>>> print(copy_command(dbs.SQLServerDB(database='source_db'), dbs.PostgreSQLDB(database='target_db'), 'target_table', None))
+        >>>> print(copy_command(dbs.SQLServerDB(database='source_db'), dbs.PostgreSQLDB(database='target_db'), \
+                                'target_table'))
         sed 's/\\\\$/\$/g;s/\$/\\\\$/g' \
           | sqsh  -D source_db -m csv \
-          | PGTZ=Europe/Berlin PGOPTIONS=--client-min-messages=warning psql --echo-all --no-psqlrc --set ON_ERROR_STOP=on target_db \
+          | PGTZ=Europe/Berlin PGOPTIONS=--client-min-messages=warning psql --echo-all --no-psqlrc \
+               --set ON_ERROR_STOP=on target_db \
                --command="COPY target_table FROM STDIN WITH CSV HEADER"
     """
     raise NotImplementedError(
-        f'Please implement copy_command for types "{source_db.__class__.__name__}" and "{target_db.__class__.__name__}"')
+        f'Please implement copy_command for types "{source_db.__class__.__name__}" and "{target_db.__class__.__name__}"'
+    )
 
 
 @copy_command.register(str, str)
-def __(source_db_alias: str, target_db_alias: str, target_table: str, timezone: str = None):
-    return copy_command(dbs.db(source_db_alias), dbs.db(target_db_alias), target_table, timezone)
+def __(source_db_alias: str, target_db_alias: str, target_table: str, timezone: str = None,
+       csv_format: bool = None, delimiter_char: str = None):
+    return copy_command(dbs.db(source_db_alias), dbs.db(target_db_alias),
+                        target_table=target_table, timezone=timezone,
+                        csv_format=csv_format, delimiter_char=delimiter_char)
 
 
 @copy_command.register(dbs.DB, str)
-def __(source_db: dbs.DB, target_db_alias: str, target_table: str, timezone: str = None):
-    return copy_command(source_db, dbs.db(target_db_alias), target_table, timezone)
+def __(source_db: dbs.DB, target_db_alias: str, target_table: str, timezone: str = None,
+       csv_format: bool = None, delimiter_char: str = None):
+    return copy_command(source_db, dbs.db(target_db_alias),
+                        target_table=target_table, timezone=timezone,
+                        csv_format=csv_format, delimiter_char=delimiter_char)
 
 
 @copy_command.register(dbs.PostgreSQLDB, dbs.PostgreSQLDB)
-def __(source_db: dbs.PostgreSQLDB, target_db: dbs.PostgreSQLDB, target_table: str, timezone: str):
-    return (copy_to_stdout_command(source_db) + ' \\\n'
+def __(source_db: dbs.PostgreSQLDB, target_db: dbs.PostgreSQLDB, target_table: str,
+       timezone: str = None, csv_format: bool = None, delimiter_char: str = None):
+    return (copy_to_stdout_command(source_db, delimiter_char=delimiter_char, csv_format=csv_format) + ' \\\n'
             + '  | ' + copy_from_stdin_command(target_db, target_table=target_table,
-                                               null_value_string='', timezone=timezone))
+                                               null_value_string='', timezone=timezone, csv_format=csv_format,
+                                               delimiter_char=delimiter_char))
 
 
 @copy_command.register(dbs.MysqlDB, dbs.PostgreSQLDB)
-def __(source_db: dbs.MysqlDB, target_db: dbs.PostgreSQLDB, target_table: str, timezone: str):
+def __(source_db: dbs.MysqlDB, target_db: dbs.PostgreSQLDB, target_table: str,
+       timezone: str = None, csv_format: bool = None, delimiter_char: str = None):
     return (copy_to_stdout_command(source_db) + ' \\\n'
             + '  | ' + copy_from_stdin_command(target_db, target_table=target_table,
-                                               null_value_string='NULL', timezone=timezone))
+                                               null_value_string='NULL', timezone=timezone,
+                                               csv_format=csv_format, delimiter_char=delimiter_char))
 
 
 @copy_command.register(dbs.SQLServerDB, dbs.PostgreSQLDB)
-def __(source_db: dbs.SQLServerDB, target_db: dbs.PostgreSQLDB, target_table: str, timezone: str):
+def __(source_db: dbs.SQLServerDB, target_db: dbs.PostgreSQLDB, target_table: str,
+       timezone: str = None, csv_format: bool = None, delimiter_char: str = None):
+    if csv_format is None:
+        csv_format = True
     return (copy_to_stdout_command(source_db) + ' \\\n'
-            + '  | ' + copy_from_stdin_command(target_db, target_table=target_table, csv_format=True,
+            + '  | ' + copy_from_stdin_command(target_db, target_table=target_table, csv_format=csv_format,
+                                               delimiter_char=delimiter_char,
                                                skip_header=True, timezone=timezone))
 
 
 @copy_command.register(dbs.OracleDB, dbs.PostgreSQLDB)
-def __(source_db: dbs.OracleDB, target_db: dbs.PostgreSQLDB, target_table: str, timezone: str):
+def __(source_db: dbs.OracleDB, target_db: dbs.PostgreSQLDB, target_table: str,
+       timezone: str = None, csv_format: bool = None, delimiter_char: str = None):
+    if csv_format is None:
+        csv_format = True
+
     return (copy_to_stdout_command(source_db) + ' \\\n'
-            + '  | ' + copy_from_stdin_command(target_db, target_table=target_table, csv_format=True, skip_header=False,
+            + '  | ' + copy_from_stdin_command(target_db, target_table=target_table,
+                                               csv_format=csv_format, skip_header=False, delimiter_char=delimiter_char,
                                                null_value_string='NULL', timezone=timezone))
 
 
 @copy_command.register(dbs.SQLiteDB, dbs.PostgreSQLDB)
-def __(source_db: dbs.SQLiteDB, target_db: dbs.PostgreSQLDB, target_table: str, timezone: str):
+def __(source_db: dbs.SQLiteDB, target_db: dbs.PostgreSQLDB, target_table: str,
+       timezone: str = None, csv_format: bool = None, delimiter_char: str = None):
+    if csv_format is None:
+        csv_format = True
     return (copy_to_stdout_command(source_db) + ' \\\n'
             + '  | ' + copy_from_stdin_command(target_db, target_table=target_table, timezone=timezone,
-                                               null_value_string='NULL', quote_char="''", csv_format=True))
+                                               null_value_string='NULL', quote_char="''", csv_format=csv_format,
+                                               delimiter_char=delimiter_char))

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         'SQLAlchemy>=1.1.5',
         'sqlalchemy-utils>=0.32.14',
         'alembic>=0.8.10',
-        'multimethod>=0.7.1',
+        'multimethod>=1.0.0',
         'graphviz>=0.8',
         'mara-page>=1.3.0',
         'psycopg2-binary>=2.7.3'],


### PR DESCRIPTION
…s for better quoting JSONS, arrays, strings with tabs

Add delimiter_char parameter to copy_command function

Add warnings for unused parameters

Make code a bit more pep-8 compliant