### PR TITLE
set up mssql severity to 10

### DIFF
--- a/mara_db/shell.py
+++ b/mara_db/shell.py
@@ -103,7 +103,7 @@ def __(db: dbs.SQLServerDB, timezone: str = None, echo_queries: bool = None):
     command += "(cat && echo ';') \\\n  | "
     command += "(cat && echo ';\n\go') \\\n  | "
 
-    return (command + 'sqsh -a 1 -d 0 -f 0'
+    return (command + 'sqsh -a 1 -d 0 -f 10'
             + (f' -U {db.user}' if db.user else '')
             + (f' -P {db.password}' if db.password else '')
             + (f' -S {db.host}' if db.host else '')


### PR DESCRIPTION
MSSQL considers errors with severity up to 10 as OK. When setting the severity to zero (0), you do not even allow PRINT commands which are at severity 1.

Note: SQL Server Management Studio shows "Query executed successfully" as long as severity is 10 or below. From severity level 11 the software shows "Query completed with errors".

Take a look as well at:
* https://docs.microsoft.com/de-de/sql/t-sql/language-elements/raiserror-transact-sql?view=sql-server-ver15
* https://sqlity.net/en/984/print-vs-raiserror/ (this shows a bit testing with severity levels)