### PR TITLE
fix remove dollar character escaping

### DIFF
--- a/mara_db/shell.py
+++ b/mara_db/shell.py
@@ -95,12 +95,8 @@ def __(db: dbs.MysqlDB, timezone: str = None, echo_queries: bool = None):
 def __(db: dbs.SQLServerDB, timezone: str = None, echo_queries: bool = None):
     assert all(v is None for v in [timezone, echo_queries]), "unimplemented parameter for SQLServerDB"
 
-    # sqsh is not able to use '$' directly, it has to be quoted by two backslashes
-    # first, undo the quoting in case it has already been applied, then quote
-    command = "sed 's/\\\\\\\\$/\$/g;s/\$/\\\\\\\\$/g' | "
-
     # sqsh does not do anything when a statement is not terminated by a ';', add one to be sure
-    command += "(cat && echo ';') \\\n  | "
+    command = "(cat && echo ';') \\\n  | "
     command += "(cat && echo ';\n\go') \\\n  | "
 
     return (command + 'sqsh -a 1 -d 0 -f 10'
@@ -353,8 +349,7 @@ def copy_command(source_db: object, target_db: object, target_table: str,
     Examples:
         >>>> print(copy_command(dbs.SQLServerDB(database='source_db'), dbs.PostgreSQLDB(database='target_db'), \
                                 'target_table'))
-        sed 's/\\\\$/\$/g;s/\$/\\\\$/g' \
-          | sqsh  -D source_db -m csv \
+        sqsh  -D source_db -m csv \
           | PGTZ=Europe/Berlin PGOPTIONS=--client-min-messages=warning psql --echo-all --no-psqlrc \
                --set ON_ERROR_STOP=on target_db \
                --command="COPY target_table FROM STDIN WITH CSV HEADER"


### PR DESCRIPTION
I use sqsh version sqsh-2.5.16.1 and I see no reason here escaping dollar signs; it just creates problems when using dollar signs and should be removed. The execution works when I remove the escaping, and since nothing crashes, I don't see the point in escaping dollar signs at all.

I made a test with this file:
``` sql
PRINT 'TEST DOLLAR SIGN $ HERE'
```

when I execute it with the current version (with dollar character escaping):

![image](https://user-images.githubusercontent.com/26678883/79340060-14a60500-7f2a-11ea-96fd-bfb33cb82fa5.png)


when I execute it with this fix:

![image](https://user-images.githubusercontent.com/26678883/79340058-12dc4180-7f2a-11ea-87f5-4c79841f1254.png)
