### PR TITLE
Escape double quotes in copy_from_sdtin_command for PostgreSQL

### DIFF
--- a/mara_db/shell.py
+++ b/mara_db/shell.py
@@ -296,6 +296,9 @@ def __(db: dbs.PostgreSQLDB, target_table: str, csv_format: bool = None, skip_he
     if quote_char is not None:
         sql += f" QUOTE AS '{quote_char}'"
 
+    # escape double quotes
+    sql = sql.replace('"','\\"')
+
     return f'{query_command(db, timezone)} \\\n      --command="{sql}"'
 
 


### PR DESCRIPTION
Currently, this Copy command: 

```python            
Copy(sql_statement='SELECT 1', source_db_alias='dwh',
          target_table='metabase_next."Order items"', target_db_alias='metabase-data'),
```

produces this output:

```bash
echo 'SELECT 1' \
  | PGTZ=Europe/Berlin PGOPTIONS=--client-min-messages=warning psql --username=root --host=localhost  --no-psqlrc --set ON_ERROR_STOP=on example_project_1_dwh --variable=FETCH_COUNT=10000 --tuples-only --pset="footer=off" --no-align --field-separator='	' \
  | sed '/^$/d' \
  | PGTZ=Europe/Berlin PGOPTIONS=--client-min-messages=warning psql --username=root --host=127.0.0.1 --echo-all --no-psqlrc --set ON_ERROR_STOP=on example_project_1_metabase_data \
      --command="COPY metabase_next."Order items" FROM STDIN WITH NULL AS ''"
```

Which fails to run because the quotes in the table name are not quoted. This PR will fix that, the output will be 

```bash
echo 'SELECT 1' \
  | PGTZ=Europe/Berlin PGOPTIONS=--client-min-messages=warning psql --username=root --host=localhost  --no-psqlrc --set ON_ERROR_STOP=on example_project_1_dwh --variable=FETCH_COUNT=10000 --tuples-only --pset="footer=off" --no-align --field-separator='	' \
  | sed '/^$/d' \
  | PGTZ=Europe/Berlin PGOPTIONS=--client-min-messages=warning psql --username=root --host=127.0.0.1 --echo-all --no-psqlrc --set ON_ERROR_STOP=on example_project_1_metabase_data \
      --command="COPY metabase_next.\"Order items\" FROM STDIN WITH NULL AS ''"
```

However, this might break other things that I'm not aware of.

It would be great if a few people could try whether that breaks things