### PR TITLE
fix COPY PostgreSQLDB  --> BigQueryDB when delimiter_char is not set

### DIFF
--- a/mara_db/shell.py
+++ b/mara_db/shell.py
@@ -468,7 +468,7 @@ def __(source_db: dbs.PostgreSQLDB, target_db: dbs.PostgreSQLDB, target_table: s
     return (copy_to_stdout_command(source_db, delimiter_char=delimiter_char, csv_format=csv_format) + ' \\\n'
             + '  | ' + copy_from_stdin_command(target_db, target_table=target_table,
                                                timezone=timezone, csv_format=csv_format,
-                                               delimiter_char=delimiter_char))
+                                               delimiter_char='\t' if not delimiter_char and csv_format else delimiter_char))
 
 
 @copy_command.register(dbs.MysqlDB, dbs.PostgreSQLDB)


### PR DESCRIPTION
Postgres uses by default tab as csv separator, BigQuery by default something else. With this fix the Copy pipeline command works without setting the determitter manually.

@gathineou Can you confirm that this works for you?