### PR TITLE
add support for SQLServerDB TCP/IP port

### DIFF
--- a/mara_db/dbs.py
+++ b/mara_db/dbs.py
@@ -100,8 +100,11 @@ class MysqlDB(DB):
 
 
 class SQLServerDB(DB):
-    def __init__(self, host: str = None, database: str = None, user: str = None, password: str = None, odbc_driver: str = None):
+    def __init__(self, host: str = None, port: int = None, database: str = None,
+                 user: str = None, password: str = None, odbc_driver: str = None):
+        # NOTE: The support for named instances is not added because the command `sqsh` does not support it
         self.host = host
+        self.port = port
         self.database = database
         self.user = user
         self.password = password

--- a/mara_db/shell.py
+++ b/mara_db/shell.py
@@ -122,7 +122,8 @@ def __(db: dbs.SQLServerDB, timezone: str = None, echo_queries: bool = None):
     return (command + 'sqsh -a 1 -d 0 -f 10'
             + (f' -U {db.user}' if db.user else '')
             + (f' -P {db.password}' if db.password else '')
-            + (f' -S {db.host}' if db.host else '')
+            + (f' -S {db.host}' if db.host and not db.port else '')
+            + (f' -S {db.host}:{db.port}' if db.host and db.port else '')
             + (f' -D {db.database}' if db.database else '')
             + (f' -e' if echo_queries else ''))
 

--- a/mara_db/sqlserver.py
+++ b/mara_db/sqlserver.py
@@ -17,7 +17,12 @@ def sqlserver_cursor_context(db: typing.Union[str, mara_db.dbs.SQLServerDB]) -> 
     assert (isinstance(db, mara_db.dbs.SQLServerDB))
 
     cursor = None
-    connection = pyodbc.connect(f"DRIVER={{{db.odbc_driver}}};SERVER={db.host};DATABASE={db.database};UID={db.user};PWD={db.password}")
+
+    server = db.host
+    if db.port: # connecting via TCP/IP port
+        server = f"{server},{db.port}"
+
+    connection = pyodbc.connect(f"DRIVER={{{db.odbc_driver}}};SERVER={server};DATABASE={db.database};UID={db.user};PWD={db.password}")
     try:
         cursor = connection.cursor()
         yield cursor


### PR DESCRIPTION
This adds support to use another TCP/IP port as 1433 (= default SQL Server port).

Note: I added a few comments in relation to named instaces e.g. "MYSERVER\MYINSTANCE_NAME". Since `sqsh` does not support named instances as far as I see, I did not add support.

_Note:_ I did not test this since all my SQL databases are running on default port.