### PR TITLE
add config default_echo_queries

### DIFF
--- a/mara_db/config.py
+++ b/mara_db/config.py
@@ -17,6 +17,13 @@ def default_timezone() -> str:
     return 'Europe/Berlin'
 
 
+def default_echo_queries() -> bool:
+    """
+    If queries should be printed on execution by default, if applicable
+    """
+    return True
+
+
 def schema_ui_foreign_key_column_regex() -> typing.Pattern:
     """A regex that classifies a table column as being used in a foreign constraint (for coloring missing constraints)"""
     return r'.*_fk$'

--- a/mara_db/shell.py
+++ b/mara_db/shell.py
@@ -45,7 +45,7 @@ def __(alias: str, timezone: str = None, echo_queries: bool = None):
 @query_command.register(dbs.PostgreSQLDB)
 def __(db: dbs.PostgreSQLDB, timezone: str = None, echo_queries: bool = None):
     if echo_queries is None:
-        echo_queries = True
+        echo_queries = config.default_echo_queries()
 
     return (f'PGTZ={timezone or config.default_timezone()} '
             + (f"PGPASSWORD='{db.password}' " if db.password else '')
@@ -65,7 +65,7 @@ def __(db: dbs.PostgreSQLDB, timezone: str = None, echo_queries: bool = None):
 @query_command.register(dbs.RedshiftDB)
 def __(db: dbs.RedshiftDB, timezone: str = None, echo_queries: bool = None):
     if echo_queries is None:
-        echo_queries = True
+        echo_queries = config.default_echo_queries()
 
     return (f'PGTZ={timezone or config.default_timezone()} '
             + (f"PGPASSWORD='{db.password}' " if db.password else '')
@@ -113,7 +113,7 @@ def __(db: dbs.SQLServerDB, timezone: str = None, echo_queries: bool = None):
     assert all(v is None for v in [timezone]), "unimplemented parameter for SQLServerDB"
 
     if echo_queries is None:
-        echo_queries = True
+        echo_queries = config.default_echo_queries()
 
     # sqsh does not do anything when a statement is not terminated by a ';', add one to be sure
     command = "(cat && echo ';') \\\n  | "


### PR DESCRIPTION
Gives the option to define a default behavior for parameter `echo_queries` in function `query_command` as it is already done for paramter `timezone`.