### PR TITLE
Use sqlcmd #39

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The following **command line clients** are used to access the various databases:
 | --- | --- | --- |
 | Postgresql / Redshift | `psql` | Included in standard distributions. |
 | MariaDB / Mysql | `mysql` | Included in standard distributions. |
-| SQL Server | `sqsh` | From [https://sourceforge.net/projects/sqsh/](https://sourceforge.net/projects/sqsh/), usually messy to get working. On ubuntu, use [http://ppa.launchpad.net/jasc/sqsh/ubuntu/](http://ppa.launchpad.net/jasc/sqsh/ubuntu/) backport. On Mac, try the homebrew version or install from source. |
+| SQL Server | `sqsh`<br>- or -<br>`sqlcmd` | **sqsh**: From [https://sourceforge.net/projects/sqsh/](https://sourceforge.net/projects/sqsh/), usually messy to get working. On ubuntu, use [http://ppa.launchpad.net/jasc/sqsh/ubuntu/](http://ppa.launchpad.net/jasc/sqsh/ubuntu/) backport. On Mac, try the homebrew version or install from source.<br>**sqlcmd**: Official Microsoft Utility for SQL Server. See [sqlcmd Utility](https://docs.microsoft.com/en-us/sql/tools/sqlcmd-utility) |
 | Oracle | `sqlplus64` | See the [Oracle Instant Client](https://www.oracle.com/technetwork/database/database-technologies/instant-client/overview/index.html) homepage for details. On Mac, follow [these instructions](https://vanwollingen.nl/install-oracle-instant-client-and-sqlplus-using-homebrew-a233ce224bf). Then ` sudo ln -s /usr/local/bin/sqlplus /usr/local/bin/sqlplus64` to make the binary accessible as `sqlplus64`. |
 | SQLite | `sqlite3` | Available in standard distributions. Version >3.20.x required (not the case on Ubuntu 14.04). |
 | Big Query | `bq` | See the [Google Cloud SDK](https://cloud.google.com/sdk/docs/quickstarts) page for details. |

--- a/mara_db/dbs.py
+++ b/mara_db/dbs.py
@@ -114,6 +114,30 @@ class SQLServerDB(DB):
             self.odbc_driver = odbc_driver
 
 
+class SqlcmdSQLServerDB(SQLServerDB):
+    def __init__(self, host: str = None, instance: str = None, port: int = None, database: str = None,
+                 user: str = None, password: str = None, odbc_driver: str = None,
+                 protocol: str = None, quoted_identifier: bool = True):
+        """
+        Args:
+            quoted_identifier: If set to true, the SET option QUOTED_IDENTIFIER is set to ON, otherwise OFF.
+            protocol: can be tcp (TCP/IP connection), np (named pipe) or lcp (using shared memory). See as well: https://docs.microsoft.com/en-us/sql/ssms/scripting/sqlcmd-connect-to-the-database-engine?view=sql-server-ver15
+        """
+        super().__init__(host=host, port=port, database=database, user=user, password=password, odbc_driver=odbc_driver)
+        if protocol:
+            if protocol not in ['tcp','np','lpc']:
+                raise ValueError(f'Not supported protocol: {protocol}')
+            if protocol == 'tcp' and instance:
+                raise ValueError(f'You can not use protocol tcp with an instance name')
+            if protocol in ['np','lcp'] and port:
+                raise ValueError(f'You can not use protocol np/lcp with a port number')
+        if instance is not None and port is not None:
+            raise ValueError('You can only use instance or port, not both together')
+        self.protocol = protocol
+        self.quoted_identifier = quoted_identifier
+        self.instance = instance
+
+
 class OracleDB(DB):
     def __init__(self, host: str = None, port: int = 0, endpoint: str = None, user: str = None, password: str = None):
         self.host = host

--- a/mara_db/shell.py
+++ b/mara_db/shell.py
@@ -557,6 +557,17 @@ def __(source_db: dbs.SQLServerDB, target_db: dbs.PostgreSQLDB, target_table: st
                                                skip_header=True, timezone=timezone))
 
 
+@copy_command.register(dbs.SqlcmdSQLServerDB, dbs.PostgreSQLDB)
+def __(source_db: dbs.SQLServerDB, target_db: dbs.PostgreSQLDB, target_table: str,
+       timezone: str = None, csv_format: bool = None, delimiter_char: str = None):
+    if csv_format is None:
+        csv_format = True
+    return (copy_to_stdout_command(source_db) + ' \\\n'
+            + '  | ' + copy_from_stdin_command(target_db, target_table=target_table, csv_format=csv_format,
+                                               delimiter_char=delimiter_char,
+                                               null_value_string='NULL', skip_header=True, timezone=timezone))
+
+
 @copy_command.register(dbs.SQLServerDB, dbs.BigQueryDB)
 def __(source_db: dbs.SQLServerDB, target_db: dbs.PostgreSQLDB, target_table: str,
        timezone: str = None, csv_format: bool = None, delimiter_char: str = None):
@@ -566,6 +577,17 @@ def __(source_db: dbs.SQLServerDB, target_db: dbs.PostgreSQLDB, target_table: st
             + '  | ' + copy_from_stdin_command(target_db, target_table=target_table, csv_format=csv_format,
                                                delimiter_char=delimiter_char,
                                                skip_header=True, timezone=timezone))
+
+
+@copy_command.register(dbs.SqlcmdSQLServerDB, dbs.BigQueryDB)
+def __(source_db: dbs.SQLServerDB, target_db: dbs.PostgreSQLDB, target_table: str,
+       timezone: str = None, csv_format: bool = None, delimiter_char: str = None):
+    if csv_format is None:
+        csv_format = True
+    return (copy_to_stdout_command(source_db) + ' \\\n'
+            + '  | ' + copy_from_stdin_command(target_db, target_table=target_table, csv_format=csv_format,
+                                               delimiter_char=delimiter_char,
+                                               null_value_string='NULL', skip_header=True, timezone=timezone))
 
 
 @copy_command.register(dbs.OracleDB, dbs.PostgreSQLDB)


### PR DESCRIPTION
Implements an optional DB connector to use `sqlcmd`. #39 

### Speed
The general execution speed is faster with sqlcmd:

![image](https://user-images.githubusercontent.com/46843047/99093101-55562180-25d2-11eb-8189-5e40df530211.png)

### Issue with CSV quotation

There is a known issue that `copy_to_stdout_command` returns a CSV where fields will not be double-quoted with `"`. This seems not to be possible, except you solve this in your SQL SELECT query e.g. like this:
``` sql
SELECT
    QUOTENAME(column1) AS column1
FROM table
```

@jankatins Do you have an idea how to solve quotation for CSV?

### SET QUOTED_IDENTIFIER ON by default

The config is implemented to use the SET option [QUOTED_IDENTIFIER](https://docs.microsoft.com/en-us/sql/t-sql/statements/set-quoted-identifier-transact-sql) by default - which is not T-SQL standard.
I did this to a) enforce more SQL-Standard-like executions with mara by default and b) to avoid troubles when working with column stored indexes. They can only be created when `QUOTED_IDENTIFIER` is `ON`, and randomly this flag can not be changed via the SQL statement `SET QUOTED_IDENTIFIER ON` when running the query via `sqlcmd`.
When you guys think this is not a good idea, we can discuss this.

### Trusted connection not implemented
There is an option to use trusted connections with option `-E`. I did not do any implementation here since I can't test it. It is cumbersome to get linux running with kerberos...