### PR TITLE
add sqlalchemy support for mssql via pyodbc

### DIFF
--- a/mara_db/sqlalchemy_engine.py
+++ b/mara_db/sqlalchemy_engine.py
@@ -59,3 +59,9 @@ def __(db: mara_db.dbs.BigQueryDB):
 def __(db: mara_db.dbs.SQLiteDB):
     return sqlalchemy.create_engine(f'sqlite:///{db.file_name}')
 
+
+@engine.register(mara_db.dbs.SQLServerDB)
+def __(db: mara_db.dbs.SQLServerDB):
+    port = db.port if db.port else 1433
+    driver = db.odbc_driver.replace(' ','+')
+    return sqlalchemy.create_engine(f'mssql+pyodbc://{db.user}:{db.password}@{db.host}:{port}/{db.database}?driver={driver}')

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
 
     extras_require={
         'test': ['pytest', 'pytest_click'],
+        'mssql': ['pyodbc'],
         'bigquery':
             ['google-cloud-bigquery', # Google maintained bigquery client
              'google-cloud-bigquery-storage', # avoid warnigns in cursor contexts


### PR DESCRIPTION
This PR does two things:
* it adds SQLAlchemy support for SQL Server
* it sets `psycopg2-binary` package to an extra requirement to make it possible to use mara-db. You will not need it when you work in an environment where you don't use a PostgreSQL db

Note: After merging this you should add the extra requirements in your `requirements.txt` as following when you use PostgreSQL:
``` requirements.txt
-e git+https://github.com/mara/mara-db.git@4.7.1#egg=mara-db[postgresql]
```