### PR TITLE
add support for Snowflake databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The following **command line clients** are used to access the various databases:
 | Oracle | `sqlplus64` | See the [Oracle Instant Client](https://www.oracle.com/technetwork/database/database-technologies/instant-client/overview/index.html) homepage for details. On Mac, follow [these instructions](https://vanwollingen.nl/install-oracle-instant-client-and-sqlplus-using-homebrew-a233ce224bf). Then ` sudo ln -s /usr/local/bin/sqlplus /usr/local/bin/sqlplus64` to make the binary accessible as `sqlplus64`. |
 | SQLite | `sqlite3` | Available in standard distributions. Version >3.20.x required (not the case on Ubuntu 14.04). |
 | Big Query | `bq` | See the [Google Cloud SDK](https://cloud.google.com/sdk/docs/quickstarts) page for details. |
+| Snowflake | `snowsql` | See [SnowSQL (CLI Client)](https://docs.snowflake.com/en/user-guide/snowsql.html) |
 
 &nbsp;
 

--- a/mara_db/dbs.py
+++ b/mara_db/dbs.py
@@ -216,3 +216,34 @@ class SQLiteDB(DB):
     @property
     def sqlalchemy_url(self):
         return f'sqlite:///{self.file_name}'
+
+
+class SnowflakeDB(DB):
+    """A database connection to a Snowflake database"""
+    def __init__(self, connection: str = None, account: str = None, user: str = None, password: str = None, database: str = None,
+                 private_key_file: str = None, private_key_passphrase: str = None) -> None:
+        """
+        Connection information for a Snowflake database
+
+        Args:
+            connection: The connection name definend in the snowsql configuration ~/.snowsql/config
+            account: The account identifier. See here: https://docs.snowflake.com/en/user-guide/admin-account-identifier.html
+            user: The user name
+            password: The password of the user
+            database: The database name
+            private_key_file: Path to private key file in PEM format used for key pair authentication. The private key file must be encrypted.
+            private_key_passphrase: The passphrase for the private key file.
+        """
+        self.connection = connection
+        self.account = account
+        self.user = user
+        self.password = password
+        self.database = database
+        self.private_key_file = private_key_file
+        self.private_key_passphrase = private_key_passphrase
+
+    @property
+    def sqlalchemy_url(self):
+        assert all(v is not None for v in [self.account, self.user, self.password]), "sqlalchemy_url for SnowflakeDB requires a user, password and account"
+        return (f'snowflake://{self.user}:{self.password}@{self.account}'
+                + (f'/{self.database}' if self.database else ''))

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,8 @@ setup(
         'postgres': ['psycopg2-binary>=2.7.3'],
         'redshift': ['psycopg2-binary>=2.7.3',
                      'sqlalchemy-redshift'],
+        'snowflake': [
+            'snowflake-sqlalchemy'
+        ],
     }
 )

--- a/tests/local_config.py.example
+++ b/tests/local_config.py.example
@@ -10,3 +10,4 @@ POSTGRES_DB = dbs.PostgreSQLDB(host='DOCKER_IP', port=-1, user="mara", password=
 MSSQL_DB = None # dbs.SQLServerDB(host='DOCKER_IP', port=-1, user='sa', password='YourStrong@Passw0rd', database='master')
 MSSQL_SQSH_DB = None # dbs.SqshSQLServerDB(host='DOCKER_IP', port=-1, user='sa', password='YourStrong@Passw0rd', database='master')
 MSSQL_SQLCMD_DB = None # dbs.SqlcmdSQLServerDB(host='DOCKER_IP', port=-1, user='sa', password='YourStrong@Passw0rd', database='master', trust_server_certificate=True)
+SNOWFLAKE_DB = None #SnowflakeDB( account='ACCOUNT_IDENTIFER', user='USER', password='PASSWORD', database='SNOWFLAKE_SAMPLE_DATA')

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -1,0 +1,43 @@
+import pytest
+import subprocess
+
+from mara_db import shell, sqlalchemy_engine
+from tests.local_config import SNOWFLAKE_DB
+
+
+if not SNOWFLAKE_DB:
+    pytest.skip("skipping SnowflakeDB tests: variable SNOWFLAKE_DB not set", allow_module_level=True)
+
+
+def test_snowflake_query_command():
+    command = 'echo "SELECT 1" \\\n'
+    command += '  | ' + shell.query_command(SNOWFLAKE_DB)
+    assert command
+
+    print(command)
+    (exitcode, _) = subprocess.getstatusoutput(command)
+    assert exitcode == 0
+
+
+def test_snowflake_copy_to_stdout():
+    command = 'echo "SELECT 1 AS Col1, \'FOO\' AS Col2 UNION ALL SELECT 2, \'BAR\'" \\\n'
+    command += '  | ' + shell.copy_to_stdout_command(SNOWFLAKE_DB,
+        csv_format=True,
+        header=True,
+        delimiter_char=',')
+    assert command
+
+    print(command)
+    (exitcode, pstdout) = subprocess.getstatusoutput(command)
+    assert exitcode == 0
+    print(pstdout)
+    assert pstdout == '''"COL1","COL2"
+"1","FOO"
+"2","BAR"'''
+
+
+def test_snowflake_sqlalchemy():
+    from sqlalchemy import text
+    engine = sqlalchemy_engine.engine(SNOWFLAKE_DB)
+    with engine.connect() as con:
+        con.execute(statement = text("SELECT 1"))


### PR DESCRIPTION
This PR adds support for Snowflake.

It does not implement the `shell.copy_from_stdin_command`. Currently out of scope for me but might be easy to implement, see: [Snowflake Community: How to properly make a PUT command using STDIN](https://community.snowflake.com/s/question/0D50Z00009NCJDMSA5/how-to-properly-make-a-put-command-using-stdin)