### PR TITLE
add Databricks db support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The following **command line clients** are used to access the various databases:
 | SQLite | `sqlite3` | Available in standard distributions. Version >3.20.x required (not the case on Ubuntu 14.04). |
 | Big Query | `bq` | See the [Google Cloud SDK](https://cloud.google.com/sdk/docs/quickstarts) page for details. |
 | Snowflake | `snowsql` | See [SnowSQL (CLI Client)](https://docs.snowflake.com/en/user-guide/snowsql.html) |
+| Databricks | `dbsqlcli` | Included when using package extra `databricks` via package [databricks-sql-cli](https://pypi.org/project/databricks-sql-cli/). See [Databricks SQL CLI](https://docs.databricks.com/dev-tools/databricks-sql-cli.html#) |
 
 &nbsp;
 

--- a/docs/databases-overview.md
+++ b/docs/databases-overview.md
@@ -58,14 +58,14 @@ Copy matrix
 
 Shows which copy operations are implemented by default.
 
-| from / to    | PostgreSQLDB | RedshiftDB | BigQueryDB | MysqlDB | SQLServerDB | OracleDB | SQLiteDB |
-| ------------ | ------------ | ---------- | ---------- | ------- | ----------- | -------- | -------- |
-| PostgreSQLDB | Yes          | Yes        | Yes
-| RedshiftDB   | Yes          | Yes        | Yes
-| BigQueryDB   | Yes          | Yes        |
-| DatabricksDB |
-| MysqlDB      | Yes          | Yes        | Yes
-| SQLServerDB  | Yes          | Yes        | Yes
-| OracleDB     | Yes          | Yes        | Yes
-| SnowflakeDB  |
-| SQLiteDB     | Yes          | Yes        | Yes
+| from / to    | PostgreSQLDB | RedshiftDB | BigQueryDB | DatabricksDB | MysqlDB | SQLServerDB | OracleDB | SnowflakeDB | SQLiteDB |
+| ------------ | ------------ | ---------- | ---------- | ------------ | ------- | ----------- | -------- | ----------- | -------- |
+| PostgreSQLDB | Yes          | Yes        | Yes        | -            | -       | -           | -        | -           | -        |
+| RedshiftDB   | Yes          | Yes        | Yes        | -            | -       | -           | -        | -           | -        |
+| BigQueryDB   | Yes          | Yes        | -          | -            | -       | -           | -        | -           | -        |
+| DatabricksDB | -            | -          | -          | -            | -       | -           | -        | -           | -        |
+| MysqlDB      | Yes          | Yes        | Yes        | -            | -       | -           | -        | -           | -        |
+| SQLServerDB  | Yes          | Yes        | Yes        | -            | -       | -           | -        | -           | -        |
+| OracleDB     | Yes          | Yes        | Yes        | -            | -       | -           | -        | -           | -        |
+| SnowflakeDB  | -            | -          | -          | -            | -       | -           | -        | -           | -        |
+| SQLiteDB     | Yes          | Yes        | Yes        | -            | -       | -           | -        | -           | -        |

--- a/docs/databases-overview.md
+++ b/docs/databases-overview.md
@@ -8,6 +8,7 @@ The following database engines are supported:
 | [PostgreSQL]              | PostgreSQLDB        | postgresql+psycopg2
 | [Amazon Redshift]         | RedshiftDB          | postgresql+psycopg2
 | [Google Big Query]        | BigQueryDB          | bigquery
+| [Databricks]              | DatabricksDB        | databricks+connector
 | [MariaDB]                 | MysqlDB             | -
 | [MySQL]                   | MysqlDB             | -
 | [Microsoft SQL Server]    | SQLServerDB         | mssql+pyodbc
@@ -20,6 +21,7 @@ The following database engines are supported:
 [PostgreSQL]: https://www.postgresql.org/
 [Amazon Redshift]: https://aws.amazon.com/de/redshift/
 [Google Big Query]: https://cloud.google.com/bigquery
+[Databricks]: https://www.databricks.com/
 [MariaDB]: https://mariadb.com/
 [MySQL]: https://www.mysql.com/
 [Oracle Database]: https://www.oracle.com/database/
@@ -39,6 +41,7 @@ Shows which functions are supported with which database engine:
 | PostgreSQLDB        | Yes      | Yes          | Yes        | Yes    | Yes
 | RedshiftDB          | Yes      | Yes          | Yes        | Yes    | Yes
 | BigQueryDB          | Yes      | Yes          | Yes        | Yes    | *no foreign key support by engine*
+| DatabricksDB        | Yes      | Yes          | -          | Yes    |
 | MysqlDB             | Yes      | Yes          | -          | Yes    | Yes
 | SQLServerDB         | Yes      | Yes          | -          | Yes    | Yes
 | OracleDB            | Yes      | Yes          | -          | -      |
@@ -60,6 +63,7 @@ Shows which copy operations are implemented by default.
 | PostgreSQLDB | Yes          | Yes        | Yes
 | RedshiftDB   | Yes          | Yes        | Yes
 | BigQueryDB   | Yes          | Yes        |
+| DatabricksDB |
 | MysqlDB      | Yes          | Yes        | Yes
 | SQLServerDB  | Yes          | Yes        | Yes
 | OracleDB     | Yes          | Yes        | Yes

--- a/docs/dbs/Databricks.rst
+++ b/docs/dbs/Databricks.rst
@@ -1,0 +1,85 @@
+Databricks
+==========
+
+
+Installation
+------------
+
+Use extras `databricks` to install all required packages.
+
+.. code-block:: shell
+
+    $ pip install mara-db[databricks]
+
+The official `dbsqlcli` client is required. See the `Install the Databricks SQL CLI <https://docs.databricks.com/dev-tools/databricks-sql-cli.html#install-the-databricks-sql-cli>`_ page for installation details.
+
+
+Configuration examples
+----------------------
+
+.. tabs::
+
+    .. group-tab:: Use access token
+
+        .. code-block:: python
+
+            import mara_db.dbs
+            mara_db.config.databases = lambda: {
+                'dwh': mara_db.dbs.DatabricksDB(
+                    host='dbc-a1b2345c-d6e78.cloud.databricks.com',
+                    http_path='/sql/1.0/warehouses/1abc2d3456e7f890a',
+                    access_token='dapi1234567890b2cd34ef5a67bc8de90fa12b'),
+            }
+
+    .. group-tab:: Environment variables
+
+        .. code-block:: python
+
+            import mara_db.dbs
+            mara_db.config.databases = lambda: {
+                'dwh': mara_db.dbs.DatabricksDB(),
+            }
+
+        You need to define the environment variables `DBSQLCLI_HOST_NAME`, `DBSQLCLI_HTTP_PATH` and `DBSQLCLI_ACCESS_TOKEN`. See as well `Environment variables <https://docs.databricks.com/dev-tools/databricks-sql-cli.html#environment-variables>`_
+
+    .. group-tab:: Settings file
+
+        .. code-block:: python
+
+            import mara_db.dbs
+            mara_db.config.databases = lambda: {
+                'dwh': mara_db.dbs.DatabricksDB(),
+            }
+        
+        You need to define the database connection in the `dbsqlclirc` settings file. See as well `Settings file <https://docs.databricks.com/dev-tools/databricks-sql-cli.html#settings-file>`_. Note that using a custom settings file is currently not supported in Mara.
+
+|
+
+|
+
+API reference
+-------------
+
+This section contains database specific API in the module.
+
+.. module:: mara_db.databricks
+
+Configuration
+~~~~~~~~~~~~~
+
+.. module:: mara_db.dbs
+    :noindex:
+
+.. autoclass:: DatabricksDB
+    :special-members: __init__
+    :inherited-members:
+    :members:
+
+
+Cursor context
+~~~~~~~~~~~~~~
+
+.. module:: mara_db.databricks
+    :noindex:
+
+.. autofunction:: databricks_cursor_context

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,6 +51,7 @@ This section focuses on the supported database engines.
    dbs/PostgreSQL
    dbs/Redshift
    dbs/BigQuery
+   dbs/Databricks
    dbs/Oracle
    dbs/SQLServer
    dbs/Mysql

--- a/mara_db/databricks.py
+++ b/mara_db/databricks.py
@@ -1,0 +1,31 @@
+"""Easy access to Databricks databases via databricks-sql-connector"""
+
+import contextlib
+import typing
+
+import mara_db.dbs
+
+
+@contextlib.contextmanager
+def databricks_cursor_context(db: typing.Union[str, mara_db.dbs.DatabricksDB]) \
+        -> 'databricks.sql.client.Cursor':
+    from databricks_dbapi import odbc
+
+    if isinstance(db, str):
+        db = mara_db.dbs.db(db)
+
+    assert (isinstance(db, mara_db.dbs.DatabricksDB))
+
+    connection = odbc.connect(
+        host=db.host,
+        http_path=db.http_path,
+        token=db.access_token,
+        driver_path=db.odbc_driver_path)
+
+    cursor = connection.cursor()  # type: databricks.sql.client.Cursor
+    try:
+        yield cursor
+        connection.commit()
+    except Exception as e:
+        connection.close()
+        raise e

--- a/mara_db/dbs.py
+++ b/mara_db/dbs.py
@@ -247,3 +247,23 @@ class SnowflakeDB(DB):
         assert all(v is not None for v in [self.account, self.user, self.password]), "sqlalchemy_url for SnowflakeDB requires a user, password and account"
         return (f'snowflake://{self.user}:{self.password}@{self.account}'
                 + (f'/{self.database}' if self.database else ''))
+
+
+class DatabricksDB(DB):
+    """A database connection to a Databricks"""
+    def __init__(self, host: str = None, http_path: str = None, access_token: str = None) -> None:
+        """
+        Connection information for a Databricks
+
+        Args:
+            host: The hostname
+            http_path: The http path
+            access_token: The Access Token
+        """
+        self.host = host
+        self.http_path = http_path
+        self.access_token = access_token
+
+    @property
+    def sqlalchemy_url(self):
+        return f"databricks+connector://token:{self.access_token}@{self.host}:443/"

--- a/mara_db/shell.py
+++ b/mara_db/shell.py
@@ -390,6 +390,8 @@ def __(db: dbs.DatabricksDB, header: bool = None, footer: bool = None, delimiter
 
     if not header:
         remove_header = 'sed 1d'
+    else:
+        remove_header = None
 
     if delimiter_char == ',':
         table_format = 'csv'

--- a/mara_db/sqlalchemy_engine.py
+++ b/mara_db/sqlalchemy_engine.py
@@ -42,3 +42,13 @@ def __(db: mara_db.dbs.BigQueryDB):
     return sqlalchemy.create_engine(url,
                                     credentials_path=db.service_account_json_file_name,
                                     location=db.location)
+
+
+@engine.register(mara_db.dbs.DatabricksDB)
+def __(db: mara_db.dbs.DatabricksDB):
+    url = db.sqlalchemy_url
+
+    return sqlalchemy.create_engine(url,
+                                    connect_args={
+                                        "http_path": db.http_path
+                                    })

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,10 @@ setup(
         'snowflake': [
             'snowflake-sqlalchemy'
         ],
+        'databricks': [
+            'databricks-sql-cli',
+            'databricks-sql-connector',
+            'sqlalchemy-databricks',
+        ]
     }
 )

--- a/tests/local_config.py.example
+++ b/tests/local_config.py.example
@@ -10,4 +10,5 @@ POSTGRES_DB = dbs.PostgreSQLDB(host='DOCKER_IP', port=-1, user="mara", password=
 MSSQL_DB = None # dbs.SQLServerDB(host='DOCKER_IP', port=-1, user='sa', password='YourStrong@Passw0rd', database='master')
 MSSQL_SQSH_DB = None # dbs.SqshSQLServerDB(host='DOCKER_IP', port=-1, user='sa', password='YourStrong@Passw0rd', database='master')
 MSSQL_SQLCMD_DB = None # dbs.SqlcmdSQLServerDB(host='DOCKER_IP', port=-1, user='sa', password='YourStrong@Passw0rd', database='master', trust_server_certificate=True)
-SNOWFLAKE_DB = None #SnowflakeDB( account='ACCOUNT_IDENTIFER', user='USER', password='PASSWORD', database='SNOWFLAKE_SAMPLE_DATA')
+SNOWFLAKE_DB = None #dbs.SnowflakeDB( account='ACCOUNT_IDENTIFER', user='USER', password='PASSWORD', database='SNOWFLAKE_SAMPLE_DATA')
+DATABRICKS_DB = None #dbs.DatabricksDB(host='DBSQLCLI_HOST_NAME', http_path='DBSQLCLI_HTTP_PATH', access_token='DBSQLCLI_ACCESS_TOKEN')

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -1,0 +1,43 @@
+import pytest
+import subprocess
+
+from mara_db import shell, sqlalchemy_engine
+from tests.local_config import DATABRICKS_DB
+
+
+if not DATABRICKS_DB:
+    pytest.skip("skipping DatabricksDB tests: variable DATABRICKS_DB not set", allow_module_level=True)
+
+
+def test_databricks_query_command():
+    command = 'echo "SELECT 1" \\\n'
+    command += '  | ' + shell.query_command(DATABRICKS_DB)
+    assert command
+
+    print(command)
+    (exitcode, _) = subprocess.getstatusoutput(command)
+    assert exitcode == 0
+
+
+def test_databricks_copy_to_stdout():
+    command = 'echo "SELECT 1 AS Col1, \'FOO\' AS Col2 UNION ALL SELECT 2, \'BAR\'" \\\n'
+    command += '  | ' + shell.copy_to_stdout_command(DATABRICKS_DB,
+        csv_format=True,
+        header=True,
+        delimiter_char=',')
+    assert command
+
+    print(command)
+    (exitcode, pstdout) = subprocess.getstatusoutput(command)
+    assert exitcode == 0
+    print(pstdout)
+    assert pstdout == '''Col1,Col2
+1,FOO
+2,BAR'''
+
+
+def test_databricks_sqlalchemy():
+    from sqlalchemy import text
+    engine = sqlalchemy_engine.engine(DATABRICKS_DB)
+    with engine.connect() as con:
+        con.execute(statement = text("SELECT 1"))


### PR DESCRIPTION
This PR adds support for Databricks including
* shell `query_command` and `copy_to_stdout_command` via `dbsqlcli`, pypi package [databricks-sql-cli](https://pypi.org/project/databricks-sql-cli/)
* cursor via `mara_db.databricks.databricks_cursor_context` using pypi package [databricks-sql-connector](https://pypi.org/project/databricks-sql-connector/)
* sqlalchemy support via pypi package [sqlalchemy-databricks](https://pypi.org/project/sqlalchemy-databricks/)

### Open tasks
* [x] add rtd documentation
* [x] update Readme.md
* [x] testing the implementation