### PR TITLE
Refactor cursor_context calls

### DIFF
--- a/mara_db/bigquery.py
+++ b/mara_db/bigquery.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import typing
+from warnings import warn
 
 import mara_db.dbs
 import sys
@@ -35,6 +36,8 @@ def bigquery_client(db: typing.Union[str, mara_db.dbs.BigQueryDB]) -> 'google.cl
 def bigquery_cursor_context(db: typing.Union[str, mara_db.dbs.BigQueryDB]) \
         -> 'google.cloud.bigquery.dbapi.cursor.Cursor':
     """Creates a context with a bigquery cursor for a database alias"""
+    warn('Function bigquery_cursor_context(db) is deprecated. Please use db.cursor_context() instead.')
+
     if isinstance(db, str):
         db = mara_db.dbs.db(db)
 

--- a/mara_db/bigquery.py
+++ b/mara_db/bigquery.py
@@ -35,18 +35,12 @@ def bigquery_client(db: typing.Union[str, mara_db.dbs.BigQueryDB]) -> 'google.cl
 def bigquery_cursor_context(db: typing.Union[str, mara_db.dbs.BigQueryDB]) \
         -> 'google.cloud.bigquery.dbapi.cursor.Cursor':
     """Creates a context with a bigquery cursor for a database alias"""
-    client = bigquery_client(db)
+    if isinstance(db, str):
+        db = mara_db.dbs.db(db)
 
-    from google.cloud.bigquery.dbapi.connection import Connection
+    assert (isinstance(db, mara_db.dbs.BigQueryDB))
 
-    connection = Connection(client)
-    cursor = connection.cursor()  # type: google.cloud.bigquery.dbapi.cursor.Cursor
-    try:
-        yield cursor
-        connection.commit()
-    except Exception as e:
-        connection.close()
-        raise e
+    return db.cursor_context()
 
 
 def create_bigquery_table_from_postgresql_query(

--- a/mara_db/databricks.py
+++ b/mara_db/databricks.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import typing
+from warnings import warn
 
 import mara_db.dbs
 
@@ -9,6 +10,8 @@ import mara_db.dbs
 @contextlib.contextmanager
 def databricks_cursor_context(db: typing.Union[str, mara_db.dbs.DatabricksDB]) \
         -> 'databricks.sql.client.Cursor':
+    warn('Function databricks_cursor_context(db) is deprecated. Please use db.cursor_context() instead.')
+
     if isinstance(db, str):
         db = mara_db.dbs.db(db)
 

--- a/mara_db/databricks.py
+++ b/mara_db/databricks.py
@@ -9,23 +9,9 @@ import mara_db.dbs
 @contextlib.contextmanager
 def databricks_cursor_context(db: typing.Union[str, mara_db.dbs.DatabricksDB]) \
         -> 'databricks.sql.client.Cursor':
-    from databricks_dbapi import odbc
-
     if isinstance(db, str):
         db = mara_db.dbs.db(db)
 
     assert (isinstance(db, mara_db.dbs.DatabricksDB))
 
-    connection = odbc.connect(
-        host=db.host,
-        http_path=db.http_path,
-        token=db.access_token,
-        driver_path=db.odbc_driver_path)
-
-    cursor = connection.cursor()  # type: databricks.sql.client.Cursor
-    try:
-        yield cursor
-        connection.commit()
-    except Exception as e:
-        connection.close()
-        raise e
+    return db.cursor_context()

--- a/mara_db/dbs.py
+++ b/mara_db/dbs.py
@@ -1,5 +1,6 @@
 """Abstract definition of database connections"""
 
+import contextlib
 import functools
 import pathlib
 
@@ -37,6 +38,7 @@ class DB:
         """
         raise NotImplementedError(f'Please implement connect for type "{self.__class__.__name__}"')
 
+    @contextlib.contextmanager
     def cursor_context(self) -> object:
         """
         A single iteration with a cursor context. When the iteration is
@@ -50,11 +52,10 @@ class DB:
         try:
             cursor = connection.cursor()
             yield cursor
+            connection.commit()
         except Exception:
             connection.rollback()
             raise
-        else:
-            connection.commit()
         finally:
             cursor.close()
             connection.close()

--- a/mara_db/mysql.py
+++ b/mara_db/mysql.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import typing
+from warnings import warn
 
 import mara_db.dbs
 
@@ -9,6 +10,8 @@ import mara_db.dbs
 @contextlib.contextmanager
 def mysql_cursor_context(db: typing.Union[str, mara_db.dbs.MysqlDB]) -> 'MySQLdb.cursors.Cursor':
     """Creates a context with a mysql-client cursor for a database alias or database"""
+    warn('Function mysql_cursor_context(db) is deprecated. Please use db.cursor_context() instead.')
+
     if isinstance(db, str):
         db = mara_db.dbs.db(db)
 

--- a/mara_db/mysql.py
+++ b/mara_db/mysql.py
@@ -9,25 +9,9 @@ import mara_db.dbs
 @contextlib.contextmanager
 def mysql_cursor_context(db: typing.Union[str, mara_db.dbs.MysqlDB]) -> 'MySQLdb.cursors.Cursor':
     """Creates a context with a mysql-client cursor for a database alias or database"""
-    import MySQLdb.cursors # requires https://github.com/PyMySQL/mysqlclient-python
-
     if isinstance(db, str):
         db = mara_db.dbs.db(db)
 
     assert (isinstance(db, mara_db.dbs.MysqlDB))
 
-    cursor = None
-    connection = MySQLdb.connect(
-        host=db.host, user=db.user, passwd=db.password, db=db.database, port=db.port,
-        cursorclass=MySQLdb.cursors.Cursor)
-    try:
-        cursor = connection.cursor()
-        yield cursor
-    except Exception:
-        connection.rollback()
-        raise
-    else:
-        connection.commit()
-    finally:
-        cursor.close()
-        connection.close()
+    return db.cursor_context()

--- a/mara_db/postgresql.py
+++ b/mara_db/postgresql.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import typing
+from warnings import warn
 
 import mara_db.dbs
 
@@ -9,6 +10,8 @@ import mara_db.dbs
 @contextlib.contextmanager
 def postgres_cursor_context(db: typing.Union[str, mara_db.dbs.PostgreSQLDB]) -> 'psycopg2.extensions.cursor':
     """Creates a context with a psycopg2 cursor for a database alias"""
+    warn('Function databricks_cursor_context(db) is deprecated. Please use db.cursor_context() instead.')
+
     if isinstance(db, str):
         db = mara_db.dbs.db(db)
 

--- a/mara_db/postgresql.py
+++ b/mara_db/postgresql.py
@@ -2,28 +2,16 @@
 
 import contextlib
 import typing
+
 import mara_db.dbs
 
 
 @contextlib.contextmanager
 def postgres_cursor_context(db: typing.Union[str, mara_db.dbs.PostgreSQLDB]) -> 'psycopg2.extensions.cursor':
     """Creates a context with a psycopg2 cursor for a database alias"""
-    import psycopg2
-    import psycopg2.extensions
-
     if isinstance(db, str):
         db = mara_db.dbs.db(db)
 
     assert (isinstance(db, mara_db.dbs.PostgreSQLDB))
-    connection = psycopg2.connect(dbname=db.database, user=db.user, password=db.password,
-                                  host=db.host, port=db.port)  # type: psycopg2.extensions.connection
-    cursor = connection.cursor()  # type: psycopg2.extensions.cursor
-    try:
-        yield cursor
-        connection.commit()
-    except Exception as e:
-        connection.rollback()
-        raise e
-    finally:
-        cursor.close()
-        connection.close()
+
+    return db.cursor_context()

--- a/mara_db/sqlserver.py
+++ b/mara_db/sqlserver.py
@@ -9,29 +9,9 @@ import mara_db.dbs
 @contextlib.contextmanager
 def sqlserver_cursor_context(db: typing.Union[str, mara_db.dbs.SQLServerDB]) -> 'pyodbc.Cursor':
     """Creates a context with a pyodbc-client cursor for a database alias or database"""
-    import pyodbc # requires https://github.com/mkleehammer/pyodbc/wiki/Install
-
     if isinstance(db, str):
         db = mara_db.dbs.db(db)
 
     assert (isinstance(db, mara_db.dbs.SQLServerDB))
 
-    cursor = None
-
-    server = db.host
-    if db.port: # connecting via TCP/IP port
-        server = f"{server},{db.port}"
-
-    connection = pyodbc.connect(f"DRIVER={{{db.odbc_driver}}};SERVER={server};DATABASE={db.database};UID={db.user};PWD={db.password}" \
-                                + (';Encrypt=YES;TrustServerCertificate=YES' if db.trust_server_certificate else ''))
-    try:
-        cursor = connection.cursor()
-        yield cursor
-    except Exception:
-        connection.rollback()
-        raise
-    else:
-        connection.commit()
-    finally:
-        cursor.close()
-        connection.close()
+    return db.cursor_context()

--- a/mara_db/sqlserver.py
+++ b/mara_db/sqlserver.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import typing
+from warnings import warn
 
 import mara_db.dbs
 
@@ -9,6 +10,8 @@ import mara_db.dbs
 @contextlib.contextmanager
 def sqlserver_cursor_context(db: typing.Union[str, mara_db.dbs.SQLServerDB]) -> 'pyodbc.Cursor':
     """Creates a context with a pyodbc-client cursor for a database alias or database"""
+    warn('Function sqlserver_cursor_context(db) is deprecated. Please use db.cursor_context() instead.')
+
     if isinstance(db, str):
         db = mara_db.dbs.db(db)
 

--- a/tests/db_test_helper.py
+++ b/tests/db_test_helper.py
@@ -40,3 +40,18 @@ def _test_sqlalchemy(db):
         # the SELECT of a scalar value without a table is
         # appropriately formatted for the backend
         assert conn.scalar(select(1)) == 1
+
+def _test_connect(db):
+    connection = db.connect()
+    cursor = connection.cursor()
+    try:
+        cursor.execute('SELECT 1')
+        row = cursor.fetchone()
+        assert row[0] == 1
+        connection.commit()
+    except Exception as e:
+        connection.rollback()
+        raise e
+    finally:
+        cursor.close()
+        connection.close()

--- a/tests/db_test_helper.py
+++ b/tests/db_test_helper.py
@@ -26,7 +26,7 @@ def db_replace_placeholders(db: dbs.DB, docker_ip: str, docker_port: int) -> dbs
 Basic tests which can be used for different DB engines.
 """
 
-def _test_sqlalchemy(db):
+def _test_sqlalchemy(db: dbs.DB):
     """
     A simple test to check if the SQLAlchemy connection works
     """
@@ -41,7 +41,7 @@ def _test_sqlalchemy(db):
         # appropriately formatted for the backend
         assert conn.scalar(select(1)) == 1
 
-def _test_connect(db):
+def _test_connect(db: dbs.DB):
     connection = db.connect()
     cursor = connection.cursor()
     try:
@@ -55,3 +55,9 @@ def _test_connect(db):
     finally:
         cursor.close()
         connection.close()
+
+def _test_cursor_context(db: dbs.DB):
+    with db.cursor_context() as cursor:
+        cursor.execute('SELECT 1')
+        row = cursor.fetchone()
+        assert row[0] == 1

--- a/tests/mssql/test_mssql.py
+++ b/tests/mssql/test_mssql.py
@@ -64,6 +64,14 @@ def test_mssql_connect(mssql_db):
     _test_connect(mssql_db)
 
 
+def test_mssql_cursor_context(mssql_db):
+    """
+    A simple test to check if the cursor context of the db works.
+    """
+    from ..db_test_helper import _test_cursor_context
+    _test_cursor_context(mssql_db)
+
+
 
 """
 #################################################################################################################################

--- a/tests/mssql/test_mssql.py
+++ b/tests/mssql/test_mssql.py
@@ -63,8 +63,9 @@ def test_mssql_connect(mssql_db):
     connection = MSSQL_DB.connect()
     cursor = connection.cursor()
     try:
-        for row in cursor.execute('SELECT 1'):
-            assert row[0] == 1
+        cursor.execute('SELECT 1')
+        row = cursor.fetchone()
+        assert row[0] == 1
         connection.commit()
     except Exception as e:
         connection.rollback()

--- a/tests/mssql/test_mssql.py
+++ b/tests/mssql/test_mssql.py
@@ -56,6 +56,24 @@ def test_mssql_sqlalchemy(mssql_db):
     _test_sqlalchemy(mssql_db)
 
 
+def test_mssql_connect(mssql_db):
+    """
+    A simple test to check if the connect API works.
+    """
+    connection = MSSQL_DB.connect()
+    cursor = connection.cursor()
+    try:
+        for row in cursor.execute('SELECT 1'):
+            assert row[0] == 1
+        connection.commit()
+    except Exception as e:
+        connection.rollback()
+        raise e
+    finally:
+        cursor.close()
+        connection.close()
+
+
 
 """
 #################################################################################################################################

--- a/tests/mssql/test_mssql.py
+++ b/tests/mssql/test_mssql.py
@@ -60,19 +60,8 @@ def test_mssql_connect(mssql_db):
     """
     A simple test to check if the connect API works.
     """
-    connection = MSSQL_DB.connect()
-    cursor = connection.cursor()
-    try:
-        cursor.execute('SELECT 1')
-        row = cursor.fetchone()
-        assert row[0] == 1
-        connection.commit()
-    except Exception as e:
-        connection.rollback()
-        raise e
-    finally:
-        cursor.close()
-        connection.close()
+    from ..db_test_helper import _test_connect
+    _test_connect(mssql_db)
 
 
 

--- a/tests/postgres/test_postgres.py
+++ b/tests/postgres/test_postgres.py
@@ -158,3 +158,11 @@ def test_postgres_connect(postgres_db):
     """
     from ..db_test_helper import _test_connect
     _test_connect(postgres_db)
+
+
+def test_postgres_cursor_context(postgres_db):
+    """
+    A simple test to check if the cursor context of the db works.
+    """
+    from ..db_test_helper import _test_cursor_context
+    _test_cursor_context(postgres_db)

--- a/tests/postgres/test_postgres.py
+++ b/tests/postgres/test_postgres.py
@@ -150,3 +150,21 @@ def test_postgres_sqlalchemy(postgres_db):
     """
     from ..db_test_helper import _test_sqlalchemy
     _test_sqlalchemy(postgres_db)
+
+
+def test_postgres_connect(postgres_db):
+    """
+    A simple test to check if the connect API works.
+    """
+    connection = POSTGRES_DB.connect()
+    cursor = connection.cursor()
+    try:
+        for row in cursor.execute('SELECT 1'):
+            assert row[0] == 1
+        connection.commit()
+    except Exception as e:
+        connection.rollback()
+        raise e
+    finally:
+        cursor.close()
+        connection.close()

--- a/tests/postgres/test_postgres.py
+++ b/tests/postgres/test_postgres.py
@@ -156,16 +156,5 @@ def test_postgres_connect(postgres_db):
     """
     A simple test to check if the connect API works.
     """
-    connection = POSTGRES_DB.connect()
-    cursor = connection.cursor()
-    try:
-        cursor.execute('SELECT 1')
-        row = cursor.fetchone()
-        assert row[0] == 1
-        connection.commit()
-    except Exception as e:
-        connection.rollback()
-        raise e
-    finally:
-        cursor.close()
-        connection.close()
+    from ..db_test_helper import _test_connect
+    _test_connect(postgres_db)

--- a/tests/postgres/test_postgres.py
+++ b/tests/postgres/test_postgres.py
@@ -159,8 +159,9 @@ def test_postgres_connect(postgres_db):
     connection = POSTGRES_DB.connect()
     cursor = connection.cursor()
     try:
-        for row in cursor.execute('SELECT 1'):
-            assert row[0] == 1
+        cursor.execute('SELECT 1')
+        row = cursor.fetchone()
+        assert row[0] == 1
         connection.commit()
     except Exception as e:
         connection.rollback()

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -47,16 +47,5 @@ def test_databricks_connect():
     """
     A simple test to check if the connect API works.
     """
-    connection = DATABRICKS_DB.connect()
-    cursor = connection.cursor()
-    try:
-        cursor.execute('SELECT 1')
-        row = cursor.fetchone()
-        assert row[0] == 1
-        connection.commit()
-    except Exception as e:
-        connection.rollback()
-        raise e
-    finally:
-        cursor.close()
-        connection.close()
+    from .db_test_helper import _test_connect
+    _test_connect(DATABRICKS_DB)

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -50,8 +50,9 @@ def test_databricks_connect():
     connection = DATABRICKS_DB.connect()
     cursor = connection.cursor()
     try:
-        for row in cursor.execute('SELECT 1'):
-            assert row[0] == 1
+        cursor.execute('SELECT 1')
+        row = cursor.fetchone()
+        assert row[0] == 1
         connection.commit()
     except Exception as e:
         connection.rollback()

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -41,3 +41,21 @@ def test_databricks_sqlalchemy():
     engine = sqlalchemy_engine.engine(DATABRICKS_DB)
     with engine.connect() as con:
         con.execute(statement = text("SELECT 1"))
+
+
+def test_databricks_connect():
+    """
+    A simple test to check if the connect API works.
+    """
+    connection = DATABRICKS_DB.connect()
+    cursor = connection.cursor()
+    try:
+        for row in cursor.execute('SELECT 1'):
+            assert row[0] == 1
+        connection.commit()
+    except Exception as e:
+        connection.rollback()
+        raise e
+    finally:
+        cursor.close()
+        connection.close()

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -49,3 +49,11 @@ def test_databricks_connect():
     """
     from .db_test_helper import _test_connect
     _test_connect(DATABRICKS_DB)
+
+
+def test_databricks_cursor_context():
+    """
+    A simple test to check if the cursor context of the db works.
+    """
+    from .db_test_helper import _test_cursor_context
+    _test_cursor_context(DATABRICKS_DB)


### PR DESCRIPTION
Implement two methods to directly connect to the DB API (PEP-249):

``` python
class DB:

    # [...]

    def connect(self) -> object:
        """
        Constructor for creating a connection to the database.
        The returned connection object is PIP-249 compatible (DB-API).

        See also: https://peps.python.org/pep-0249/#connection-objects
        """
        raise NotImplementedError(f'Please implement connect for type "{self.__class__.__name__}"')

    def cursor_context(self) -> object:
        """
        A single iteration with a cursor context. When the iteration is
        closed, a commit is executed on the cursor.

        Example usage:
           with db.cursor_context() as cursor:
             cursor.execute('UPDATE table SET table.c1 = 1 WHERE table.id = 5')
        """
        # [...]
```

With that, we mark the individual database calls deprecated.