### PR TITLE
redesign connect, cursor_context from #68 to a public functional API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,6 +15,10 @@ DBs
 
 .. autofunction:: db
 
+.. autofunction:: connect
+
+.. autofunction:: cursor_context
+
 
 Auto migration
 --------------

--- a/docs/databases-overview.md
+++ b/docs/databases-overview.md
@@ -36,17 +36,17 @@ Function support matrix
 
 Shows which functions are supported with which database engine:
 
-| Configuration class | Querying | Write STDOUT | Read STDIN | Cursor | UI schema support |
-| ------------------- | -------- | ------------ | ---------- | ------ | ----------------- |
-| PostgreSQLDB        | Yes      | Yes          | Yes        | Yes    | Yes
-| RedshiftDB          | Yes      | Yes          | Yes        | Yes    | Yes
-| BigQueryDB          | Yes      | Yes          | Yes        | Yes    | *no foreign key support by engine*
-| DatabricksDB        | Yes      | Yes          | -          | Yes    |
-| MysqlDB             | Yes      | Yes          | -          | Yes    | Yes
-| SQLServerDB         | Yes      | Yes          | -          | Yes    | Yes
-| OracleDB            | Yes      | Yes          | -          | -      |
-| SnowflakeDB         | Yes      | Yes          | -          | -      |
-| SQLiteDB            | Yes      | Yes          | -          | -      |
+| Configuration class | Querying | Write STDOUT | Read STDIN | DB-API 2.0 | UI schema support |
+| ------------------- | -------- | ------------ | ---------- | ---------- | ----------------- |
+| PostgreSQLDB        | Yes      | Yes          | Yes        | Yes        | Yes
+| RedshiftDB          | Yes      | Yes          | Yes        | Yes        | Yes
+| BigQueryDB          | Yes      | Yes          | Yes        | Yes        | *no foreign key support by engine*
+| DatabricksDB        | Yes      | Yes          | -          | Yes        |
+| MysqlDB             | Yes      | Yes          | -          | Yes        | Yes
+| SQLServerDB         | Yes      | Yes          | -          | Yes        | Yes
+| OracleDB            | Yes      | Yes          | -          | -          |
+| SnowflakeDB         | Yes      | Yes          | -          | -          |
+| SQLiteDB            | Yes      | Yes          | -          | Yes        |
 
 *Write STDOUT* gives the possibility to write a query to STDOUT
 

--- a/docs/dbs/BigQuery.rst
+++ b/docs/dbs/BigQuery.rst
@@ -84,14 +84,6 @@ Configuration
     :members:
 
 
-Cursor context
-~~~~~~~~~~~~~~
-
-.. module:: mara_db.bigquery
-    :noindex:
-
-.. autofunction:: bigquery_cursor_context
-
 General helper functions
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/dbs/Databricks.rst
+++ b/docs/dbs/Databricks.rst
@@ -74,12 +74,3 @@ Configuration
     :special-members: __init__
     :inherited-members:
     :members:
-
-
-Cursor context
-~~~~~~~~~~~~~~
-
-.. module:: mara_db.databricks
-    :noindex:
-
-.. autofunction:: databricks_cursor_context

--- a/docs/dbs/Mysql.rst
+++ b/docs/dbs/Mysql.rst
@@ -51,12 +51,3 @@ Configuration
     :special-members: __init__
     :inherited-members:
     :members:
-
-
-Cursor context
-~~~~~~~~~~~~~~
-
-.. module:: mara_db.mysql
-    :noindex:
-
-.. autofunction:: mysql_cursor_context

--- a/docs/dbs/PostgreSQL.rst
+++ b/docs/dbs/PostgreSQL.rst
@@ -72,13 +72,3 @@ Configuration
     :special-members: __init__
     :inherited-members:
     :members:
-
-
-Cursor context
-~~~~~~~~~~~~~~
-
-.. module:: mara_db.postgresql
-    :noindex:
-
-.. autofunction:: postgres_cursor_context
-    :noindex:

--- a/docs/dbs/Redshift.rst
+++ b/docs/dbs/Redshift.rst
@@ -82,12 +82,3 @@ Configuration
     :special-members: __init__
     :inherited-members:
     :members:
-
-
-Cursor context
-~~~~~~~~~~~~~~
-
-.. module:: mara_db.postgresql
-    :noindex:
-
-.. autofunction:: postgres_cursor_context

--- a/docs/dbs/SQLServer.rst
+++ b/docs/dbs/SQLServer.rst
@@ -146,12 +146,3 @@ Configuration
     :special-members: __init__
     :inherited-members:
     :members:
-
-
-Cursor context
-~~~~~~~~~~~~~~
-
-.. module:: mara_db.sqlserver
-    :noindex:
-
-.. autofunction:: sqlserver_cursor_context

--- a/mara_db/bigquery.py
+++ b/mara_db/bigquery.py
@@ -43,7 +43,7 @@ def bigquery_cursor_context(db: typing.Union[str, mara_db.dbs.BigQueryDB]) \
 
     assert (isinstance(db, mara_db.dbs.BigQueryDB))
 
-    return db.cursor_context()
+    return mara_db.dbs.cursor_context(db)
 
 
 def create_bigquery_table_from_postgresql_query(

--- a/mara_db/databricks.py
+++ b/mara_db/databricks.py
@@ -17,4 +17,4 @@ def databricks_cursor_context(db: typing.Union[str, mara_db.dbs.DatabricksDB]) \
 
     assert (isinstance(db, mara_db.dbs.DatabricksDB))
 
-    return db.cursor_context()
+    return mara_db.dbs.cursor_context(db)

--- a/mara_db/mysql.py
+++ b/mara_db/mysql.py
@@ -17,4 +17,4 @@ def mysql_cursor_context(db: typing.Union[str, mara_db.dbs.MysqlDB]) -> 'MySQLdb
 
     assert (isinstance(db, mara_db.dbs.MysqlDB))
 
-    return db.cursor_context()
+    return mara_db.dbs.cursor_context(db)

--- a/mara_db/postgresql.py
+++ b/mara_db/postgresql.py
@@ -17,4 +17,4 @@ def postgres_cursor_context(db: typing.Union[str, mara_db.dbs.PostgreSQLDB]) -> 
 
     assert (isinstance(db, mara_db.dbs.PostgreSQLDB))
 
-    return db.cursor_context()
+    return mara_db.dbs.cursor_context(db)

--- a/mara_db/sqlserver.py
+++ b/mara_db/sqlserver.py
@@ -17,4 +17,4 @@ def sqlserver_cursor_context(db: typing.Union[str, mara_db.dbs.SQLServerDB]) -> 
 
     assert (isinstance(db, mara_db.dbs.SQLServerDB))
 
-    return db.cursor_context()
+    return mara_db.dbs.cursor_context(db)

--- a/tests/db_test_helper.py
+++ b/tests/db_test_helper.py
@@ -42,7 +42,7 @@ def _test_sqlalchemy(db: dbs.DB):
         assert conn.scalar(select(1)) == 1
 
 def _test_connect(db: dbs.DB):
-    connection = db.connect()
+    connection = dbs.connect(db)
     cursor = connection.cursor()
     try:
         cursor.execute('SELECT 1')
@@ -57,7 +57,7 @@ def _test_connect(db: dbs.DB):
         connection.close()
 
 def _test_cursor_context(db: dbs.DB):
-    with db.cursor_context() as cursor:
+    with dbs.cursor_context(db) as cursor:
         cursor.execute('SELECT 1')
         row = cursor.fetchone()
         assert row[0] == 1


### PR DESCRIPTION
@jankatins I thought again about it and came to the point that the mara functional API standard would make more sence, as you proposed. So I redesigned it now before releasing version 4.9.0.

So the functions `connect` and `cursor_context` are now on the root level of `mara_db.dbs`. This makes it more DB-API 2.0 compliant I think...

[PEP-249#constructors](https://peps.python.org/pep-0249/#constructors)

Do you want to review?