### PR TITLE
hotfix issue with postgres cursor context

### DIFF
--- a/mara_db/bigquery.py
+++ b/mara_db/bigquery.py
@@ -1,6 +1,5 @@
 """Easy access to BigQuery databases via google.cloud.bigquery"""
 
-import contextlib
 import typing
 from warnings import warn
 
@@ -32,7 +31,6 @@ def bigquery_client(db: typing.Union[str, mara_db.dbs.BigQueryDB]) -> 'google.cl
     return Client(project=credentials.project_id, credentials=credentials, location=db.location)
 
 
-@contextlib.contextmanager
 def bigquery_cursor_context(db: typing.Union[str, mara_db.dbs.BigQueryDB]) \
         -> 'google.cloud.bigquery.dbapi.cursor.Cursor':
     """Creates a context with a bigquery cursor for a database alias"""

--- a/mara_db/databricks.py
+++ b/mara_db/databricks.py
@@ -1,13 +1,11 @@
 """Easy access to Databricks databases via databricks-sql-connector"""
 
-import contextlib
 import typing
 from warnings import warn
 
 import mara_db.dbs
 
 
-@contextlib.contextmanager
 def databricks_cursor_context(db: typing.Union[str, mara_db.dbs.DatabricksDB]) \
         -> 'databricks.sql.client.Cursor':
     warn('Function databricks_cursor_context(db) is deprecated. Please use db.cursor_context() instead.')

--- a/mara_db/mysql.py
+++ b/mara_db/mysql.py
@@ -1,13 +1,11 @@
 """Easy access to MySQL databases via mysql-client"""
 
-import contextlib
 import typing
 from warnings import warn
 
 import mara_db.dbs
 
 
-@contextlib.contextmanager
 def mysql_cursor_context(db: typing.Union[str, mara_db.dbs.MysqlDB]) -> 'MySQLdb.cursors.Cursor':
     """Creates a context with a mysql-client cursor for a database alias or database"""
     warn('Function mysql_cursor_context(db) is deprecated. Please use db.cursor_context() instead.')

--- a/mara_db/postgresql.py
+++ b/mara_db/postgresql.py
@@ -1,13 +1,11 @@
 """Easy access to postgres databases via psycopg2"""
 
-import contextlib
 import typing
 from warnings import warn
 
 import mara_db.dbs
 
 
-@contextlib.contextmanager
 def postgres_cursor_context(db: typing.Union[str, mara_db.dbs.PostgreSQLDB]) -> 'psycopg2.extensions.cursor':
     """Creates a context with a psycopg2 cursor for a database alias"""
     warn('Function databricks_cursor_context(db) is deprecated. Please use db.cursor_context() instead.')

--- a/mara_db/sqlserver.py
+++ b/mara_db/sqlserver.py
@@ -1,13 +1,11 @@
 """Easy access to SQLServer databases via pyodbc-client"""
 
-import contextlib
 import typing
 from warnings import warn
 
 import mara_db.dbs
 
 
-@contextlib.contextmanager
 def sqlserver_cursor_context(db: typing.Union[str, mara_db.dbs.SQLServerDB]) -> 'pyodbc.Cursor':
     """Creates a context with a pyodbc-client cursor for a database alias or database"""
     warn('Function sqlserver_cursor_context(db) is deprecated. Please use db.cursor_context() instead.')

--- a/tests/postgres/test_postgres.py
+++ b/tests/postgres/test_postgres.py
@@ -166,3 +166,15 @@ def test_postgres_cursor_context(postgres_db):
     """
     from ..db_test_helper import _test_cursor_context
     _test_cursor_context(postgres_db)
+
+
+def test_postgres_cursor_context_legacy(postgres_db):
+    """
+    A simple test to check if the cursor context of the db works.
+    """
+    from mara_db.postgresql import postgres_cursor_context
+
+    with postgres_cursor_context(postgres_db) as cursor:
+        cursor.execute('SELECT 1')
+        row = cursor.fetchone()
+        assert row[0] == 1

--- a/tests/postgres/test_postgres.py
+++ b/tests/postgres/test_postgres.py
@@ -170,7 +170,9 @@ def test_postgres_cursor_context(postgres_db):
 
 def test_postgres_cursor_context_legacy(postgres_db):
     """
-    A simple test to check if the cursor context of the db works.
+    Legacy call `postgres_cursor_context` test.
+    
+    Test shall be dropped in version 5.0
     """
     from mara_db.postgresql import postgres_cursor_context
 


### PR DESCRIPTION
Existing mara apps will break with 4.9.0 because `postgres_cursor_context` breaks with an exception. This fixes the issue