### PR TITLE
add mara_db click group

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,7 +3,7 @@ API
 
 .. module:: mara_db
 
-This part of the documentation covers all the interfaces of Mara Page. For
+This part of the documentation covers all the interfaces of Mara DB. For
 parts where the package depends on external libraries, we document the most
 important right here and provide links to the canonical documentation.
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,29 @@
+CLI
+===
+
+.. module:: mara_db.cli
+
+The following 
+This part of the documentation covers all the available cli commands of Mara DB.
+
+
+``migrate``
+-----------
+
+.. tabs::
+
+    .. group-tab:: Mara CLI
+
+        .. code-block:: shell
+
+            mara db migrate
+
+    .. group-tab:: Mara Flask App
+
+        .. code-block:: python
+
+            flask mara-db migrate
+
+
+Compares the current database db alias `mara` with all defined models and applies
+the diff using alembic.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -3,7 +3,6 @@ CLI
 
 .. module:: mara_db.cli
 
-The following 
 This part of the documentation covers all the available cli commands of Mara DB.
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,6 +59,17 @@ This section focuses on the supported database engines.
    dbs/SQLite
 
 
+CLI commands
+------------
+
+When you are looking at available CLI commands, here you are at the right place.
+
+.. toctree::
+   :maxdepth: 2
+
+   cli
+
+
 API Reference
 -------------
 

--- a/mara_db/__init__.py
+++ b/mara_db/__init__.py
@@ -23,7 +23,8 @@ def MARA_ACL_RESOURCES():
 
 def MARA_CLICK_COMMANDS():
     from . import cli
-    return [cli.migrate]
+    return [cli.mara_db,
+            cli._migrate]
 
 
 def MARA_NAVIGATION_ENTRIES():

--- a/mara_db/cli.py
+++ b/mara_db/cli.py
@@ -1,14 +1,29 @@
 """Auto-migrate command line interface"""
 
-import sys
-
 import click
+import sys
+from warnings import warn
 
 
-@click.command()
+@click.group()
+def mara_db():
+    """Commands to interact with the database."""
+    pass
+
+
+@mara_db.command()
 def migrate():
     """Compares the current database with all defined models and applies the diff"""
     import mara_db.auto_migration
 
     if not mara_db.auto_migration.auto_discover_models_and_migrate():
         sys.exit(-1)
+
+
+# Old cli commands to be dropped in 5.0:
+
+@click.command("migrate")
+def _migrate():
+    """Compares the current database with all defined models and applies the diff"""
+    warn("CLI command `<app> mara_db.migrate` will be dropped in 5.0. Please use: `<app> mara-db migrate`")
+    migrate.callback()


### PR DESCRIPTION
This adds the commands via a click group. In the future, cli commands should be run via
```
flask mara-db migrate
```
instead of
```
flask mara_db.migrate
```

Using the old syntax produces a warning that the old style will be dropped in version 5.0.

In the future, a new package with an entrypoint `mara` will trim leading `mara-` from the click group name. Then it would be possible to run e.g.
```
mara db migrate
```

But to avoid complications with other packages (see discussion in https://github.com/mara/mara-app/pull/44), we use the module name as click group name.